### PR TITLE
Update Bottom Tabbar

### DIFF
--- a/lib/router/index/index_bottom_bar.dart
+++ b/lib/router/index/index_bottom_bar.dart
@@ -43,18 +43,6 @@ class _IndexBottomBar extends State<IndexBottomBar> {
     ));
     current++;
 
-    //list.add(Expanded(
-    //  child: IndexBottomBarButton(
-    //    iconData: Icons.public_rounded, // notifications_active
-    //    index: current,
-    //    selected: current == currentTap,
-    //    onDoubleTap: () {
-    //      indexProvider.globalScrollToTop();
-    //    },
-    //  ),
-    //));
-    //current++;
-
     if (!nostr!.isReadOnly()) {
       list.add(Expanded(
         child: AddBtnWrapperComponent(
@@ -70,15 +58,6 @@ class _IndexBottomBar extends State<IndexBottomBar> {
         ),
       ));
     }
-
-    //list.add(Expanded(
-    //  child: IndexBottomBarButton(
-    //    iconData: Icons.search_rounded,
-    //    index: current,
-    //    selected: current == currentTap,
-    //  ),
-    //));
-    //current++;
 
     list.add(Expanded(
       child: IndexBottomBarButton(


### PR DESCRIPTION
## Issues covered
[#31](https://github.com/verse-pbc/issues/issues/31)

## Description
This PR hides 2 tabs out of the 5 bottom tabs. This is done by deleting the code that shows the extra 2 tabs.

## How to test
1. Build the app.
2. Please check that the bottom tab bar contains just three tabs instead of 5.

## Screenshots/Video

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/1a074b8f-9c0a-4763-8587-c1b38126833d" alt="Before" width="380"/> | <img src="https://github.com/user-attachments/assets/50920b1a-d41a-468a-ba65-05b477e51978" alt="After" width="380"/> |
