### PR TITLE
Rename LoginRouter to LoginSignupWidget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -354,7 +354,7 @@ class _MyApp extends State<MyApp> {
 
     routes = {
       RouterPath.INDEX: (context) => IndexRouter(reload: reload),
-      RouterPath.LOGIN: (context) => LoginRouter(),
+      RouterPath.LOGIN: (context) => LoginSignupWidget(),
       RouterPath.DONATE: (context) => DonateRouter(),
       RouterPath.USER: (context) => UserRouter(),
       RouterPath.USER_CONTACT_LIST: (context) => UserContactListRouter(),

--- a/lib/router/index/index_router.dart
+++ b/lib/router/index/index_router.dart
@@ -133,7 +133,7 @@ class _IndexRouter extends CustState<IndexRouter>
 
     var _settingProvider = Provider.of<SettingProvider>(context);
     if (nostr == null) {
-      return LoginRouter();
+      return LoginSignupWidget();
     }
 
     if (!unlock) {

--- a/lib/router/login/login_router.dart
+++ b/lib/router/login/login_router.dart
@@ -23,14 +23,14 @@ import 'package:nostr_sdk/utils/string_util.dart';
 import '../../util/table_mode_util.dart';
 import '../index/account_manager_component.dart';
 
-class LoginRouter extends StatefulWidget {
+class LoginSignupWidget extends StatefulWidget {
   @override
   State<StatefulWidget> createState() {
-    return _LoginRouter();
+    return _LoginSignupState();
   }
 }
 
-class _LoginRouter extends State<LoginRouter>
+class _LoginSignupState extends State<LoginSignupWidget>
     with SingleTickerProviderStateMixin {
   bool? checkTerms = false;
 


### PR DESCRIPTION
This PR renames
- `LoginRouter` to `LoginSignupWidget` because this isn't a router but a widget and it handles both login and signup.
-  `_LoginRouter` to `_LoginSignupState` because it is a State.