### PR TITLE
add default groups relay to Add Group widget to make it easier to use

### DIFF
--- a/lib/provider/relay_provider.dart
+++ b/lib/provider/relay_provider.dart
@@ -30,6 +30,7 @@ import '../main.dart';
 import 'data_util.dart';
 
 class RelayProvider extends ChangeNotifier {
+  static const defaultGroupsRelayAddress = 'wss://relay.groups.nip29.com';
   static RelayProvider? _relayProvider;
 
   List<String> relayAddrs = [];
@@ -59,7 +60,7 @@ class RelayProvider extends ChangeNotifier {
     var relays = parseRelayAddrs(content);
     if (relays.isEmpty) {
       relays = [
-        "wss://relay.groups.nip29.com",
+        defaultGroupsRelayAddress,
       ];
     }
 

--- a/lib/router/group/communities_widget.dart
+++ b/lib/router/group/communities_widget.dart
@@ -74,6 +74,6 @@ class _CommunitiesWidgetState extends State<CommunitiesWidget> {
   }
 
   void groupAdd() {
-    GroupAddDailog.show(context);
+    GroupAddDialog.show(context);
   }
 }

--- a/lib/router/group/group_add_dialog.dart
+++ b/lib/router/group/group_add_dialog.dart
@@ -6,34 +6,33 @@ import 'package:nostrmo/main.dart';
 
 import '../../consts/base.dart';
 import '../../generated/l10n.dart';
+import '../../provider/relay_provider.dart';
 import '../../util/router_util.dart';
 import '../../util/theme_util.dart';
 
-class GroupAddDailog extends StatefulWidget {
+class GroupAddDialog extends StatefulWidget {
+  const GroupAddDialog({super.key});
+
   static Future<String?> show(BuildContext context) async {
     return await showDialog<String>(
         context: context,
         useRootNavigator: false,
-        builder: (_context) {
-          return GroupAddDailog();
+        builder: (_) {
+          return const GroupAddDialog();
         });
   }
 
   @override
   State<StatefulWidget> createState() {
-    return _GroupAddDailog();
+    return _GroupAddDialog();
   }
 }
 
-class _GroupAddDailog extends State<GroupAddDailog> {
-  TextEditingController hostController = TextEditingController();
+class _GroupAddDialog extends State<GroupAddDialog> {
+  TextEditingController hostController = TextEditingController(text: RelayProvider.defaultGroupsRelayAddress);
   TextEditingController groupIdController = TextEditingController();
 
   late S localization;
-
-  // bool joinGroup = true;
-
-  // String crateGroupRelay = "wss://groups.fiatjaf.com";
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +41,6 @@ class _GroupAddDailog extends State<GroupAddDailog> {
     var mainColor = themeData.primaryColor;
     var titleFontSize = themeData.textTheme.bodyLarge!.fontSize;
     Color cardColor = themeData.cardColor;
-    var hintColor = themeData.hintColor;
 
     List<Widget> list = [];
 
@@ -55,30 +53,30 @@ class _GroupAddDailog extends State<GroupAddDailog> {
     ));
 
     list.add(Container(
-      margin: EdgeInsets.only(top: Base.BASE_PADDING),
+      margin: const EdgeInsets.only(top: Base.BASE_PADDING),
       child: TextField(
         controller: hostController,
-        autofocus: true,
         decoration: InputDecoration(
           hintText: "${localization.Please_input} ${localization.Relay}",
-          border: OutlineInputBorder(borderSide: BorderSide(width: 1)),
+          border: const OutlineInputBorder(borderSide: BorderSide(width: 1)),
         ),
       ),
     ));
 
     list.add(Container(
-      margin: EdgeInsets.only(top: Base.BASE_PADDING),
+      margin: const EdgeInsets.only(top: Base.BASE_PADDING),
       child: TextField(
         controller: groupIdController,
+        autofocus: true,
         decoration: InputDecoration(
           hintText: "${localization.Please_input} ${localization.GroupId}",
-          border: OutlineInputBorder(borderSide: BorderSide(width: 1)),
+          border: const OutlineInputBorder(borderSide: BorderSide(width: 1)),
         ),
       ),
     ));
 
     list.add(Container(
-      margin: EdgeInsets.only(top: Base.BASE_PADDING),
+      margin: const EdgeInsets.only(top: Base.BASE_PADDING),
       child: Ink(
         decoration: BoxDecoration(color: mainColor),
         child: InkWell(
@@ -90,7 +88,7 @@ class _GroupAddDailog extends State<GroupAddDailog> {
             alignment: Alignment.center,
             child: Text(
               S.of(context).Confirm,
-              style: TextStyle(
+              style: const TextStyle(
                 fontWeight: FontWeight.bold,
                 color: Colors.white,
               ),
@@ -100,22 +98,9 @@ class _GroupAddDailog extends State<GroupAddDailog> {
       ),
     ));
 
-    var main = Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: cardColor,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: list,
-      ),
-    );
-
     return Scaffold(
       backgroundColor: ThemeUtil.getDialogCoverColor(themeData),
       body: FocusScope(
-        // autofocus: true,
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: () {
@@ -131,7 +116,17 @@ class _GroupAddDailog extends State<GroupAddDailog> {
             alignment: Alignment.center,
             child: GestureDetector(
               onTap: () {},
-              child: main,
+              child: Container(
+                padding: const EdgeInsets.all(20),
+                decoration: BoxDecoration(
+                  color: cardColor,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: list,
+                ),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
While working on [this ticket](https://github.com/verse-pbc/issues/issues/50), I realized that it was difficult for th user to quickly add groups because of needing to enter in the relay address. Since we're currently testing groups only on one relay, I gave that field a default value of the relay we're using and made it autofocus on the group id field to make it easier. I also did some other non-functional cleanup with the widget.

| Before | After |
| --- | --- |
|<img width="340" alt="Running_Devices_-_plur" src="https://github.com/user-attachments/assets/8f456174-9362-462d-a633-f90117e5c438">|<img width="340" alt="Running_Devices_-_plur_and_plur__Git__and_Sourcetree" src="https://github.com/user-attachments/assets/f6888ab7-bebc-4865-8698-d753a41f47de">|

