### PR TITLE
add some relays to access existing metadata events #50

### DIFF
--- a/lib/provider/relay_provider.dart
+++ b/lib/provider/relay_provider.dart
@@ -65,6 +65,7 @@ class RelayProvider extends ChangeNotifier {
         "wss://relay.damus.io",
         "wss://purplepag.es",
         "wss://nos.lol",
+        "wss://relay.mostr.pub",
       ];
     }
 


### PR DESCRIPTION
Ticket:
https://github.com/verse-pbc/issues/issues/50

Adds a few well-known relays so that our groups views don't have as many blank profile icons.

| Before | After |
| --- | --- |
|![add-relays-before](https://github.com/user-attachments/assets/ad89697b-9f20-4ca5-9971-f5f07a9080e2)|![add-relays-after](https://github.com/user-attachments/assets/ce5ed351-1ea1-4281-964d-8969a08eba28)|