### PR TITLE
remove Group chat tab to focus on Group notes #33

### DIFF
--- a/lib/component/editor/editor_mixin.dart
+++ b/lib/component/editor/editor_mixin.dart
@@ -744,8 +744,7 @@ mixin EditorMixin {
             createdAt: getCreatedAt());
       }
     } else if (groupIdentifier != null) {
-      var eventKind = getGroupEventKind();
-      eventKind ??= EventKind.GROUP_NOTE;
+      const eventKind = EventKind.GROUP_NOTE;
       // group event
       event = Event(
           nostr!.publicKey,


### PR DESCRIPTION
https://github.com/verse-pbc/issues/issues/33

Removes the two-tab interface, focusing on just the group notes.

| Before | After |
| --- | --- |
|![tabs-before](https://github.com/user-attachments/assets/030565be-e546-4e3c-8370-b6e0e3dedada)|![tabs-after](https://github.com/user-attachments/assets/59115afb-d7e2-4f6b-94b8-9913cfe539d3)|
