### PR TITLE
fix: gray screen on TestFlight builds #69

### DIFF
--- a/lib/router/group/communities_widget.dart
+++ b/lib/router/group/communities_widget.dart
@@ -44,10 +44,8 @@ class _CommunitiesWidgetState extends State<CommunitiesWidget> {
       body: Container(
         color: ColorList.plurPurple,
         child: groupIds.isEmpty
-            ? const Expanded(
-                child: Center(
-                  child: NoCommunitiesWidget(),
-                ),
+            ? const Center(
+                child: NoCommunitiesWidget(),
               )
             : GridView.builder(
                 padding:


### PR DESCRIPTION
This issue was put back into In Progress for this bug:
https://github.com/verse-pbc/issues/issues/32

When building the app in debug mode (such as running it through the IDE), Flutter allows some internally undesirable widget hierarchies. But in release mode (such as a TestFlight build), it is less tolerant. The gray screen we're seeing is esentially a failed layout of the view.

| Before | After |
| --- | --- |
|![IMG_8899](https://github.com/user-attachments/assets/e287aba8-488c-42b1-b7c9-d8528129d1b9)|![IMG_8898](https://github.com/user-attachments/assets/7a32816c-c3bf-4e6c-96e4-deed719a1475)|
