### PR TITLE
remove unnecessary bottom bar

### DIFF
--- a/lib/router/index/index_widget.dart
+++ b/lib/router/index/index_widget.dart
@@ -357,7 +357,6 @@ class _IndexWidgetState extends CustState<IndexWidget>
             smallMode: false,
           ),
         ),
-        bottomNavigationBar: IndexBottomBar(),
       );
     }
   }


### PR DESCRIPTION
https://github.com/verse-pbc/issues/issues/70

Removes the bottom bar.

Sebastian mentioned this in the Friday morning Plur meeting.

| Before | After |
| --- | --- |
|<img width="340" alt="Running_Devices_-_plur_and_nostr_sdk__Git__and_plur__Git_" src="https://github.com/user-attachments/assets/140c86fc-cbd8-4f29-904d-2a4fbcf6ad42" />|<img width="340" alt="Running_Devices_-_plur" src="https://github.com/user-attachments/assets/0a3c5106-7c74-48f1-9f3d-2f5f829dbeb6" />|
