### PR TITLE
fix app forgets groups when added multiple at a time

### DIFF
--- a/lib/router/group/group_add_dialog.dart
+++ b/lib/router/group/group_add_dialog.dart
@@ -143,7 +143,7 @@ class _GroupAddDialog extends State<GroupAddDialog> {
       return;
     }
 
-    listProvider.addGroup(GroupIdentifier(host, groupId));
+    listProvider.joinGroup(GroupIdentifier(host, groupId));
     RouterUtil.back(context);
   }
 }

--- a/lib/router/index/index_drawer_content.dart
+++ b/lib/router/index/index_drawer_content.dart
@@ -271,9 +271,7 @@ class _IndexDrawerContentComponnent
           '0x0tLAXmNmnTTTS7',
           '7aNtrZngZmPVYu9c'
         ];
-        for (String groupId in groupIds) {
-          listProvider.addGroup(GroupIdentifier(host, groupId));
-        }
+        listProvider.joinGroups(groupIds.map((gi) => GroupIdentifier(host, gi)).toList());
       },
       smallMode: widget.smallMode,
     ));


### PR DESCRIPTION
Related to https://github.com/verse-pbc/issues/issues/68

Steps to reproduce issue:

1. Create new account
2. Navigate to side menu and tap Add test groups
3. Sign out
4. Sign back in

At this point there is only one group there, but we expected all of the test groups.