### PR TITLE
prep work for doing builds #91

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -49,7 +49,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.github.haorendashu.nostrmo"
+        applicationId "app.verse.prototype.plur"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 23
@@ -79,8 +79,8 @@ android {
             // proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    
-    namespace 'com.github.haorendashu.nostrmo'
+
+    namespace 'app.verse.prototype.plur'
 }
 
 flutter {

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.haorendashu.nostrmo">
+    package="app.verse.prototype.plur">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.haorendashu.nostrmo">
+    package="app.verse.prototype.plur">
    <application
         android:label="Plur"
         android:name="${applicationName}"

--- a/android/app/src/main/java/com/github/haorendashu/nostrmo/NostrmoPlugin.java
+++ b/android/app/src/main/java/com/github/haorendashu/nostrmo/NostrmoPlugin.java
@@ -1,4 +1,4 @@
-package com.github.haorendashu.nostrmo;
+package app.verse.prototype.plur;
 
 import java.util.HashMap;
 import java.util.List;

--- a/android/app/src/main/kotlin/com/github/haorendashu/nostrmo/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/github/haorendashu/nostrmo/MainActivity.kt
@@ -1,6 +1,6 @@
-package com.github.haorendashu.nostrmo
+package app.verse.prototype.plur
 
-import com.github.haorendashu.nostrmo.NostrmoPlugin
+import app.verse.prototype.plur.NostrmoPlugin
 
 import androidx.annotation.NonNull
 import android.os.Bundle
@@ -30,7 +30,7 @@ class MainActivity: FlutterFragmentActivity() {
                 flutterEngine.getPlugins().add(nostrmoPlugin!!)
             }
         } catch (e : Exception) {
-            Log.e(TAG, "Error registering plugin NostrmoPlugin, com.github.haorendashu.nostrmo.NostrmoPlugin", e)
+            Log.e(TAG, "Error registering plugin NostrmoPlugin, app.verse.prototype.plur.NostrmoPlugin", e)
         }
     }
 

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.haorendashu.nostrmo">
+    package="app.verse.prototype.plur">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "nostrmo")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.github.haorendashu.nostrmo")
+set(APPLICATION_ID "app.verse.prototype.plur")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = nostrmo
+PRODUCT_NAME = plur
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.github.haorendashu.nostrmo
+PRODUCT_BUNDLE_IDENTIFIER = app.verse.prototype.plur
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2023 com.github.haorendashu. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2024 Verse Communications Inc. All rights reserved.


### PR DESCRIPTION
Updates the reverse-DNS identifier of the app to prep for doing builds on Android (and all platforms really).

From:
com.github.haorendashu.nostrmo

To:
app.verse.prototype.plur