### PR TITLE
Connect Plur to groups relay

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -351,7 +351,7 @@ class MyApp extends StatefulWidget {
         final context = navigatorKey.currentContext;
         if (context != null) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            joinGroup(context, 'wss://relay.groups.nip29.com', groupId, code);
+            joinGroup(context, 'wss://communities.nos.social', groupId, code);
           });
         } else {
           print('Context is null, waiting for app to initialize...');

--- a/lib/provider/relay_provider.dart
+++ b/lib/provider/relay_provider.dart
@@ -30,7 +30,7 @@ import '../main.dart';
 import 'data_util.dart';
 
 class RelayProvider extends ChangeNotifier {
-  static const defaultGroupsRelayAddress = 'wss://relay.groups.nip29.com';
+  static const defaultGroupsRelayAddress = 'wss://communities.nos.social';
   static RelayProvider? _relayProvider;
 
   List<String> relayAddrs = [];


### PR DESCRIPTION
## Issues
https://github.com/verse-pbc/issues/issues/84

## Dependencies
#27

## Description
Now you can use the communities.nos.social relay that Daniel created. This points to it, so you can go to communities.nos.social in your browser, create a relay and copy a join link, then use that to open Plur and automatically join your group!

Update: just realized this may break our "Add test groups" feature, though I'm not 100% sure.

## To Do
- [ ] test Add test groups feature to make sure it still works
- [ ] if it doesn't, just update it to use some groups from communities.nos.social (though that may not be stable since they get deleted on restart right now)

## Testing
1. Get a join link from https://communities.nos.social
2. Paste it into a browser on a device that has Plur installed
3. Open the Plur app when prompted
4. You're in the group!
5. Verify at https://communities.nos.social that you've joined