### PR TITLE
remove radio button options in create community modal

### DIFF
--- a/lib/router/group/create_community_widget.dart
+++ b/lib/router/group/create_community_widget.dart
@@ -10,16 +10,9 @@ class CreateCommunityWidget extends StatefulWidget {
   State<CreateCommunityWidget> createState() => _CreateCommunityWidgetState();
 }
 
-enum CommunityVisibility {
-  publicAnyone,
-  publicRequest,
-  privateRequest,
-}
-
 class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
   final TextEditingController _communityNameController =
       TextEditingController();
-  CommunityVisibility selectedVisibility = CommunityVisibility.publicAnyone;
 
   @override
   Widget build(BuildContext context) {
@@ -45,63 +38,6 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
           ),
           onChanged: (text) {
             setState(() {});
-          },
-        ),
-        const SizedBox(height: 20),
-        const Text("Select visibility and posting options:"),
-        const SizedBox(height: 10),
-        ListTile(
-          contentPadding: EdgeInsets.zero,
-          title: const Text("Public + anyone can join and post"),
-          leading: Radio<CommunityVisibility>(
-            value: CommunityVisibility.publicAnyone,
-            groupValue: selectedVisibility,
-            onChanged: (value) {
-              setState(() {
-                selectedVisibility = value!;
-              });
-            },
-          ),
-          onTap: () {
-            setState(() {
-              selectedVisibility = CommunityVisibility.publicAnyone;
-            });
-          },
-        ),
-        ListTile(
-          contentPadding: EdgeInsets.zero,
-          title: const Text("Public + request to join and post"),
-          leading: Radio<CommunityVisibility>(
-            value: CommunityVisibility.publicRequest,
-            groupValue: selectedVisibility,
-            onChanged: (value) {
-              setState(() {
-                selectedVisibility = value!;
-              });
-            },
-          ),
-          onTap: () {
-            setState(() {
-              selectedVisibility = CommunityVisibility.publicRequest;
-            });
-          },
-        ),
-        ListTile(
-          contentPadding: EdgeInsets.zero,
-          title: const Text("Private + request to join"),
-          leading: Radio<CommunityVisibility>(
-            value: CommunityVisibility.privateRequest,
-            groupValue: selectedVisibility,
-            onChanged: (value) {
-              setState(() {
-                selectedVisibility = value!;
-              });
-            },
-          ),
-          onTap: () {
-            setState(() {
-              selectedVisibility = CommunityVisibility.privateRequest;
-            });
           },
         ),
         const SizedBox(height: 20),


### PR DESCRIPTION
## Issues covered
[#78](https://github.com/verse-pbc/issues/issues/78)

## Description
This PR removes the radio button options to select a group type because we are only focused on private and closed groups for now.

## How to test
1. Build the app.
2. Login and go to the communities screen.
3. Tap the plus icon at the top right.
4. You should see a create community modal.
5. Please check that there are no more options for the type of group to be created.