### PR TITLE
Tell the user when they’ve already joined a group

### DIFF
--- a/lib/provider/list_provider.dart
+++ b/lib/provider/list_provider.dart
@@ -333,7 +333,23 @@ class ListProvider extends ChangeNotifier {
   get groupIdentifiers => _groupIdentifiers;
 
   void joinGroup(JoinGroupParameters request, {BuildContext? context}) async {
+    // Check if already a member first
+    if (isGroupMember(request)) {
+      BotToast.showText(text: "You're already a member of this group.");
+      if (context != null) {
+        RouterUtil.router(context, RouterPath.GROUP_DETAIL,
+            GroupIdentifier(request.host, request.groupId));
+      }
+      return;
+    }
+
     joinGroups([request], context: context);
+  }
+
+  bool isGroupMember(JoinGroupParameters request) {
+    final groupId = GroupIdentifier(request.host, request.groupId);
+    return _groupIdentifiers
+        .any((gi) => gi.groupId == groupId.groupId && gi.host == groupId.host);
   }
 
   void joinGroups(List<JoinGroupParameters> requests,


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/83

## Description
When the user tries to join a group and they're already a member, show a toast telling them. Don't join it twice and show a duplicate group on the Communities screen.

## How to test
1. Join a group. Here's a link you can use: plur://join-community?group-id=wyrgzgfsa7o4&code=0faf79703d4fb6134ed055e3
2. Now that you're in the group, try to join it again
3. Observe message

## Screenshots/Video

### Before
https://github.com/user-attachments/assets/6cde8aca-eb53-47ba-bf95-fdebdb477860

### After 
https://github.com/user-attachments/assets/461df55e-c41b-4bf0-a321-8403248fcf25
