### PR TITLE
Notify in Slack when a TestFlight deployment fails

### DIFF
--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -1,0 +1,21 @@
+name: Slack Notifier
+
+on:
+  workflow_run:
+    workflows: ["TestFlight Release Deployment"]
+    types:
+      - completed
+
+jobs:
+  notify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "💥 GitHub Action *${{ github.event.workflow_run.name }}* has failed in the *${{ github.repository }}* repository. 💥\n<${{ github.event.workflow_run.html_url }}|View the workflow run>"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+


### PR DESCRIPTION
## Issues covered 
https://github.com/verse-pbc/issues/issues/54

## Description
This imports the Slack Notifier workflow from Nos. It should post a message in the #plur channel on Slack if a TestFlight deployment fails.

## How to test
1. Merge this so that Github will see the new workflow and run it.
2. Kick off a TestFlight deployment of the branch `gh workflow run "TestFlight Release Deployment" --ref this-branch-should-fail-to-deploy`. You can do this in the Github actions web UI or with the CLI like this: `gh workflow run "TestFlight Release Deployment" --ref this-branch-should-fail-to-deploy`
3. Verify that a Slack message is posted about the failure.