### PR TITLE
Ignore commit warning when uploading symbols

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -201,3 +201,4 @@ sentry:
   project: "plur"
   org: "verse"
   url: "https://sentry.nos.social"
+  ignore_missing: true


### PR DESCRIPTION
## Issues covered
[#248](https://github.com/verse-pbc/issues/issues/248)

## Description
The plugin we use for uploading debug symbols says that in order for the commits feature to work, the Github token we use for configuring Sentry should have `org:read` scope. I cannot check that because I don't have access to token creation, but that is a possible explanation. The proposed change ignores the error.

## How to test
1. Send a manual build to TestFlight
2. It shouldn't fail