### PR TITLE
fixed an issue where a capitalized deep links would not work #252

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new group info screen and moved the edit group button. [#188](https://github.com/verse-pbc/issues/issues/188)
 - Removed table mode option [#245](https://github.com/verse-pbc/issues/issues/245)
 - Updated home screen navigation bar to match design. [#152](https://github.com/verse-pbc/issues/issues/152)
+- Fixed an issue where a capitalized deep links would not work. [#252](https://github.com/verse-pbc/issues/issues/252)
 
 ### Known Issues
 - Communities.nos.social sometimes loses group data and prevents publishing of new notes to the group.

--- a/android/app/src/main/kotlin/com/github/haorendashu/nostrmo/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/github/haorendashu/nostrmo/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity: FlutterFragmentActivity() {
 
     private fun handleIntent(intent: Intent) {
         val data: Uri? = intent.data
-        if (data != null && "plur" == data.scheme) {
+        if (data != null && data.scheme.equals("plur", ignoreCase = true)) {
             // Pass the data to Flutter
             val channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
             channel.invokeMethod("onDeepLink", data.toString())

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -12,7 +12,7 @@ import Flutter
     }
 
     override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        if url.scheme == "plur" {
+        if url.scheme?.lowercased() == "plur" {
             // Pass the URL to Flutter
             let controller = window?.rootViewController as! FlutterViewController
             let channel = FlutterMethodChannel(name: "com.example.app/deeplink", binaryMessenger: controller.binaryMessenger)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -359,7 +359,7 @@ class MyApp extends StatefulWidget {
       print('Received deep link: $link');
 
       Uri uri = Uri.parse(link);
-      if (uri.scheme == 'plur' && uri.host == 'join-community') {
+      if (uri.scheme.toLowerCase() == 'plur' && uri.host == 'join-community') {
         String? groupId = uri.queryParameters['group-id'];
         String? code = uri.queryParameters['code'];
         // Handle the extracted parameters


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/252

## Description
Fixes an issue where capitalized deep links only launch the app but do not perform the expected action.

Note: Funny enough, this change had to be made in three different languages! (Kotlin, Swift, and Dart)

## How to test
1. Launch the app
2. Tap an invite link like "Plur://join-community?group-id=hkin3peuuc3s&code=a7b3367197b506ec4c337070"

## Screenshots/Video

Note: The group "Verse Test Group 37" is not the group being tested here.

Before:
![252-before](https://github.com/user-attachments/assets/126e15c5-3e2b-4c73-ae19-7704c398ca50)

After:
![252-after](https://github.com/user-attachments/assets/0eba87bf-6171-467a-8164-1d06003a70e4)

