### PR TITLE
Fix lint errors (followup)

### DIFF
--- a/lib/component/event/event_main_widget.dart
+++ b/lib/component/event/event_main_widget.dart
@@ -3,13 +3,11 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:markdown/markdown.dart' as md;
 import 'package:nostrmo/nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/component/content/content_video_widget.dart';
 import 'package:nostrmo/component/content/markdown/markdown_mention_event_element_builder.dart';
 import 'package:nostrmo/component/event/event_torrent_widget.dart';
 import 'package:nostrmo/component/event/event_zap_goals_widget.dart';
-import 'package:nostrmo/component/user/name_widget.dart';
 import 'package:nostrmo/component/user/simple_name_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/consts/base64.dart';
@@ -23,12 +21,10 @@ import '../../data/metadata.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
 import '../../provider/metadata_provider.dart';
-import '../../provider/replaceable_event_provider.dart';
 import '../../provider/settings_provider.dart';
 import '../../util/router_util.dart';
 import '../confirm_dialog.dart';
 import '../content/content_widget.dart';
-import '../content/content_decoder.dart';
 import '../content/content_image_widget.dart';
 import '../content/content_link_widget.dart';
 import '../content/content_tag_widget.dart';
@@ -40,7 +36,6 @@ import '../content/markdown/markdown_nevent_inline_syntax.dart';
 import '../content/markdown/markdown_nprofile_inline_syntax.dart';
 import '../content/markdown/markdown_nrelay_element_builder.dart';
 import '../content/markdown/markdown_nrelay_inline_syntax copy.dart';
-import '../image_widget.dart';
 import '../zap/zap_split_icon_widget.dart';
 import 'event_poll_widget.dart';
 import '../webview_widget.dart';
@@ -180,7 +175,8 @@ class _EventMainWidgetState extends State<EventMainWidget> {
     List<Widget> list = [];
     if (showWarning || !eventRelation.warning) {
       if (widget.event.kind == EventKind.LONG_FORM) {
-        var longFormMargin = EdgeInsets.only(bottom: Base.BASE_PADDING_HALF);
+        var longFormMargin =
+            const EdgeInsets.only(bottom: Base.BASE_PADDING_HALF);
 
         List<Widget> subList = [];
         var longFormInfo = LongFormInfo.fromEvent(widget.event);
@@ -312,7 +308,6 @@ class _EventMainWidgetState extends State<EventMainWidget> {
             );
           }
         }
-
       } else if (widget.event.kind == EventKind.STORAGE_SHARED_FILE) {
         list.add(buildStorageSharedFileWidget());
         if (!widget.inQuote) {
@@ -367,7 +362,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
               list.add(Container(
                 width: double.infinity,
                 alignment: Alignment.centerLeft,
-                margin: EdgeInsets.only(bottom: Base.BASE_PADDING_HALF),
+                margin: const EdgeInsets.only(bottom: Base.BASE_PADDING_HALF),
                 child: Text(
                   eventRelation.subject!,
                   maxLines: 10,
@@ -547,7 +542,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
             color: hintColor,
           ),
           Container(
-            margin: EdgeInsets.only(
+            margin: const EdgeInsets.only(
               left: Base.BASE_PADDING_HALF,
               right: 3,
             ),
@@ -676,7 +671,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
             MarkdownMentionEventElementBuilder(),
         MarkdownNrelayElementBuilder.TAG: MarkdownNrelayElementBuilder(),
       },
-      blockSyntaxes: [],
+      blockSyntaxes: const [],
       inlineSyntaxes: [
         MarkdownMentionEventInlineSyntax(),
         MarkdownMentionUserInlineSyntax(),
@@ -754,17 +749,17 @@ class _EventMainWidgetState extends State<EventMainWidget> {
     final localization = S.of(context);
 
     return Container(
-      margin:
-          EdgeInsets.only(bottom: Base.BASE_PADDING, top: Base.BASE_PADDING),
+      margin: const EdgeInsets.only(
+          bottom: Base.BASE_PADDING, top: Base.BASE_PADDING),
       width: double.maxFinite,
       child: Column(
         children: [
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(Icons.warning),
+              const Icon(Icons.warning),
               Container(
-                margin: EdgeInsets.only(left: Base.BASE_PADDING_HALF),
+                margin: const EdgeInsets.only(left: Base.BASE_PADDING_HALF),
                 child: Text(
                   localization.Content_warning,
                   style: TextStyle(fontSize: largeTextSize),
@@ -780,7 +775,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
               });
             },
             child: Container(
-              margin: EdgeInsets.only(top: Base.BASE_PADDING_HALF),
+              margin: const EdgeInsets.only(top: Base.BASE_PADDING_HALF),
               padding: const EdgeInsets.only(
                 top: 4,
                 bottom: 4,
@@ -793,7 +788,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
               ),
               child: Text(
                 localization.Show,
-                style: TextStyle(color: Colors.white),
+                style: const TextStyle(color: Colors.white),
               ),
             ),
           ),
@@ -873,7 +868,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
     ));
 
     return Container(
-      margin: EdgeInsets.only(top: Base.BASE_PADDING_HALF),
+      margin: const EdgeInsets.only(top: Base.BASE_PADDING_HALF),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: list,
@@ -883,9 +878,9 @@ class _EventMainWidgetState extends State<EventMainWidget> {
 }
 
 class EventReplyingComponent extends StatefulWidget {
-  String pubkey;
+  final String pubkey;
 
-  EventReplyingComponent({required this.pubkey});
+  const EventReplyingComponent({super.key, required this.pubkey});
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/component/event/event_reactions_widget.dart
+++ b/lib/component/event/event_reactions_widget.dart
@@ -10,7 +10,6 @@ import 'package:nostrmo/component/group_identifier_inherited_widget.dart';
 import 'package:nostrmo/component/json_view_dialog.dart';
 import 'package:nostrmo/component/like_text_select_bottom_sheet.dart';
 import 'package:nostrmo/consts/base.dart';
-import 'package:nostrmo/provider/group_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:screenshot/screenshot.dart';
 import 'package:share_plus/share_plus.dart';
@@ -32,15 +31,16 @@ import '../zap/zap_bottom_sheet_widget.dart';
 import 'event_top_zaps_widget.dart';
 
 class EventReactionsWidget extends StatefulWidget {
-  ScreenshotController screenshotController;
+  final ScreenshotController screenshotController;
 
-  Event event;
+  final Event event;
 
-  EventRelation eventRelation;
+  final EventRelation eventRelation;
 
-  bool showDetailBtn;
+  final bool showDetailBtn;
 
-  EventReactionsWidget({
+  const EventReactionsWidget({
+    super.key,
     required this.screenshotController,
     required this.event,
     required this.eventRelation,
@@ -164,13 +164,14 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
                 ),
                 PopupMenuItem(
                   value: "copyPubkey",
-                  child: Text(localization.Copy_Note_Pubkey, style: popFontStyle),
+                  child:
+                      Text(localization.Copy_Note_Pubkey, style: popFontStyle),
                 ),
                 PopupMenuItem(
                   value: "copyId",
                   child: Text(localization.Copy_Note_Id, style: popFontStyle),
                 ),
-                PopupMenuDivider(),
+                const PopupMenuDivider(),
               ];
 
               if (widget.showDetailBtn) {
@@ -184,7 +185,7 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
                 value: "share",
                 child: Text(localization.Share, style: popFontStyle),
               ));
-              list.add(PopupMenuDivider());
+              list.add(const PopupMenuDivider());
               if (!readOnly) {
                 if (listProvider.checkPrivateBookmark(bookmarkItem)) {
                   list.add(PopupMenuItem(
@@ -195,7 +196,8 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
                 } else {
                   list.add(PopupMenuItem(
                     value: "addToPrivateBookmark",
-                    child: Text(localization.Add_to_private_bookmark, style: popFontStyle),
+                    child: Text(localization.Add_to_private_bookmark,
+                        style: popFontStyle),
                   ));
                 }
                 if (listProvider.checkPublicBookmark(bookmarkItem)) {
@@ -207,10 +209,11 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
                 } else {
                   list.add(PopupMenuItem(
                     value: "addToPublicBookmark",
-                    child: Text(localization.Add_to_public_bookmark, style: popFontStyle),
+                    child: Text(localization.Add_to_public_bookmark,
+                        style: popFontStyle),
                   ));
                 }
-                list.add(PopupMenuDivider());
+                list.add(const PopupMenuDivider());
               }
               list.add(PopupMenuItem(
                 value: "source",
@@ -234,7 +237,7 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
                   (isGroupEvent &&
                       groupAdmins != null &&
                       groupAdmins.contains(pubkey) != null)) {
-                list.add(PopupMenuDivider());
+                list.add(const PopupMenuDivider());
                 list.add(PopupMenuItem(
                   value: "delete",
                   child: Text(
@@ -283,7 +286,7 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
                 child: GestureDetector(
               behavior: HitTestBehavior.translucent,
               onTap: openZapDialog,
-              child: Container(
+              child: SizedBox(
                 height: double.infinity,
                 child: EventReactionNumWidget(
                   num: zapNum,
@@ -346,7 +349,7 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
           ));
         }
 
-        mainList.add(Container(
+        mainList.add(SizedBox(
           height: 34,
           child: topReactionsWidget,
         ));
@@ -594,7 +597,7 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
         nostr!.broadcase(widget.event);
       }
     } else if (value == "quote") {
-      var event = await EditorWidget.open(context, initEmbeds: [
+      await EditorWidget.open(context, initEmbeds: [
         quill.CustomBlockEmbed(CustEmbedTypes.mention_event, widget.event.id)
       ]);
     }
@@ -703,23 +706,24 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
 }
 
 class EventReactionNumWidget extends StatelessWidget {
-  String? iconText;
+  final String? iconText;
 
-  IconData iconData;
+  final IconData iconData;
 
-  int num;
+  final int num;
 
-  GestureTapCallback? onTap;
+  final GestureTapCallback? onTap;
 
-  GestureLongPressCallback? onLongPress;
+  final GestureLongPressCallback? onLongPress;
 
-  Color color;
+  final Color color;
 
-  double fontSize;
+  final double fontSize;
 
-  Widget? showMoreWidget;
+  final Widget? showMoreWidget;
 
-  EventReactionNumWidget({
+  const EventReactionNumWidget({
+    super.key,
     this.iconText,
     required this.iconData,
     required this.num,
@@ -767,7 +771,7 @@ class EventReactionNumWidget extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.start,
       children: list,
     );
-    main = Container(
+    main = SizedBox(
       height: double.infinity,
       child: main,
     );
@@ -797,6 +801,7 @@ class EventReactionEmojiNumWidget extends StatelessWidget {
   double fontSize;
 
   EventReactionEmojiNumWidget({
+    super.key,
     this.iconText,
     required this.iconData,
     required this.num,

--- a/lib/nostr_sdk/event_relation.dart
+++ b/lib/nostr_sdk/event_relation.dart
@@ -64,7 +64,7 @@ class EventRelation {
     for (var i = 0; i < length; i++) {
       var tag = event.tags[i];
 
-      var mentionStr = "#[" + i.toString() + "]";
+      var mentionStr = "#[$i]";
       if (event.content.contains(mentionStr)) {
         continue;
       }
@@ -126,8 +126,7 @@ class EventRelation {
             }
 
           case "description" when event.kind == EventKind.ZAP:
-            innerZapContent =
-                SpiderUtil.subUntil(value, '\"content\":\"', '\",');
+            innerZapContent = SpiderUtil.subUntil(value, '"content":"', '",');
 
           case "imeta":
             var fileMetadata = FileMetadata.fromNIP92Tag(tag);
@@ -186,7 +185,7 @@ class EventRelation {
         var k = tag[0];
         var v = tag[1];
         if (k == "description") {
-          innerContent = SpiderUtil.subUntil(v, '\"content\":\"', '\",');
+          innerContent = SpiderUtil.subUntil(v, '"content":"', '",');
           break;
         }
       }

--- a/test/nostr_sdk/event_relation_test.dart
+++ b/test/nostr_sdk/event_relation_test.dart
@@ -1,21 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostrmo/nostr_sdk/event_kind.dart';
 import 'package:nostrmo/nostr_sdk/nip19/nip19.dart';
-import '../../lib/nostr_sdk/event_relation.dart';
-import '../../lib/nostr_sdk/event.dart';
+import 'package:nostrmo/nostr_sdk/event_relation.dart';
+import 'package:nostrmo/nostr_sdk/event.dart';
 import '../helpers/test_data.dart';
 
 void main() {
-
   group('EventRelation tag processing', () {
     test('processes p tag correctly', () {
       const pubkey = TestData.bobPubkey;
-      
+
       // Case 1: When content doesn't contain nip19 references
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['p', pubkey]],
+        tags: [
+          ['p', pubkey]
+        ],
         content: 'random content',
       );
       var relation = EventRelation.fromEvent(testEvent);
@@ -25,7 +26,9 @@ void main() {
       testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['p', pubkey]],
+        tags: [
+          ['p', pubkey]
+        ],
         content: 'nostr:${Nip19.encodePubKey(pubkey)}',
       );
       relation = EventRelation.fromEvent(testEvent);
@@ -37,7 +40,9 @@ void main() {
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['e', 'event123']],
+        tags: [
+          ['e', 'event123']
+        ],
         content: 'test content',
       );
       var relation = EventRelation.fromEvent(testEvent);
@@ -47,7 +52,9 @@ void main() {
       testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['e', 'root123', 'relay.com', 'root']],
+        tags: [
+          ['e', 'root123', 'relay.com', 'root']
+        ],
         content: 'test content',
       );
       relation = EventRelation.fromEvent(testEvent);
@@ -58,7 +65,9 @@ void main() {
       testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['e', 'reply123', 'relay.com', 'reply']],
+        tags: [
+          ['e', 'reply123', 'relay.com', 'reply']
+        ],
         content: 'test content',
       );
       testEvent.sources = ['wss://test.relay'];
@@ -70,7 +79,9 @@ void main() {
       testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['e', 'mention123', 'relay.com', 'mention']],
+        tags: [
+          ['e', 'mention123', 'relay.com', 'mention']
+        ],
         content: 'test content',
       );
       relation = EventRelation.fromEvent(testEvent);
@@ -81,7 +92,9 @@ void main() {
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['subject', 'Test Subject']],
+        tags: [
+          ['subject', 'Test Subject']
+        ],
         content: 'test content',
       );
       var relation = EventRelation.fromEvent(testEvent);
@@ -92,7 +105,9 @@ void main() {
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['content-warning', 'any value']],
+        tags: [
+          ['content-warning', 'any value']
+        ],
         content: 'test content',
       );
       var relation = EventRelation.fromEvent(testEvent);
@@ -103,7 +118,9 @@ void main() {
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['a', '30023:abc123:test']],
+        tags: [
+          ['a', '30023:abc123:test']
+        ],
         content: 'test content',
       );
       var relation = EventRelation.fromEvent(testEvent);
@@ -115,7 +132,9 @@ void main() {
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['zap', TestData.bobPubkey, 'relay.com', '2.0']],
+        tags: [
+          ['zap', TestData.bobPubkey, 'relay.com', '2.0']
+        ],
         content: 'test content',
       );
       var relation = EventRelation.fromEvent(testEvent);
@@ -126,7 +145,9 @@ void main() {
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: EventKind.ZAP,
-        tags: [['description', '{"content":"inner zap content","other":"value"}']],
+        tags: [
+          ['description', '{"content":"inner zap content","other":"value"}']
+        ],
         content: '{"content":"test zap content","other":"value"}',
       );
       testEvent.sources = ['wss://test.relay'];
@@ -138,7 +159,9 @@ void main() {
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['imeta', 'url image.com/image.jpg', 'dim 123x456', 'size 1000']],
+        tags: [
+          ['imeta', 'url image.com/image.jpg', 'dim 123x456', 'size 1000']
+        ],
         content: 'test content',
       );
       var relation = EventRelation.fromEvent(testEvent);
@@ -149,7 +172,6 @@ void main() {
       expect(metadata?.dim, equals('123x456'));
       expect(metadata?.size, equals("1000"));
     });
-
 
     test('correctly parses group identifier from h tag', () {
       // Arrange
@@ -182,7 +204,9 @@ void main() {
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
         kind: 1,
-        tags: [['unknown', 'value']],
+        tags: [
+          ['unknown', 'value']
+        ],
         content: 'test content',
       );
       var relation = EventRelation.fromEvent(testEvent);
@@ -196,4 +220,4 @@ void main() {
       expect(relation.groupIdentifier, isNull);
     });
   });
-} 
+}


### PR DESCRIPTION
## Issues covered
This fixes the lint errors introduced in https://github.com/verse-pbc/plur/pull/85

## Description
This fixes several lint errors I introduced. The new Examine Lint Changes job was merged right as I was ready to merge my PR, so I decided to address the lint errors in another PR.

Unfortunately the Examine Lint Changes job is a little over-eager, and lists lint errors that weren't actually introduced by my PR. You can read my comment about that [here](https://github.com/verse-pbc/plur/pull/85#discussion_r1989525795).

Here is the full output of the [job](https://github.com/verse-pbc/plur/actions/runs/13772372849/job/38513805991), but I have marked not-applicable (`na`) the lint errors that I don't think were actually introduced by my PR. I also ran `dart fix` on some of these files so you will see more linting errors are fixed than what is listed in the output below:
```
+[info] Use interpolation to compose strings and values (/home/runner/work/plur/plur/lib/nostr_sdk/event_relation.dart:67:24)
+[info] Unnecessary escape in string literal (/home/runner/work/plur/plur/lib/nostr_sdk/event_relation.dart:130:45)
+[info] Unnecessary escape in string literal (/home/runner/work/plur/plur/lib/nostr_sdk/event_relation.dart:130:54)
+[info] Unnecessary escape in string literal (/home/runner/work/plur/plur/lib/nostr_sdk/event_relation.dart:130:57)
+[info] Unnecessary escape in string literal (/home/runner/work/plur/plur/lib/nostr_sdk/event_relation.dart:130:63)
+[info] Unnecessary escape in string literal (/home/runner/work/plur/plur/lib/nostr_sdk/event_relation.dart:189:50)
+[info] Unnecessary escape in string literal (/home/runner/work/plur/plur/lib/nostr_sdk/event_relation.dart:189:59)
+[info] Unnecessary escape in string literal (/home/runner/work/plur/plur/lib/nostr_sdk/event_relation.dart:189:62)
+[info] Unnecessary escape in string literal (/home/runner/work/plur/plur/lib/nostr_sdk/event_relation.dart:189:68)
Warning: ] This class (or a class that this class inherits from) is marked as '@immutable', but one or more of its instance fields aren't final: EventReplyingComponent.pubkey (/home/runner/work/plur/plur/lib/component/event/event_main_widget.dart:885:7)
Warning: ] This class (or a class that this class inherits from) is marked as '@immutable', but one or more of its instance fields aren't final: EventReactionNumWidget.iconText, EventReactionNumWidget.iconData, EventReactionNumWidget.num, EventReactionNumWidget.onTap, EventReactionNumWidget.onLongPress, EventReactionNumWidget.color, EventReactionNumWidget.fontSize, EventReactionNumWidget.showMoreWidget (/home/runner/work/plur/plur/lib/component/event/event_reactions_widget.dart:705:7)
Warning: ] This class (or a class that this class inherits from) is marked as '@immutable', but one or more of its instance fields aren't final: EventReactionEmojiNumWidget.iconText, EventReactionEmojiNumWidget.iconData, EventReactionEmojiNumWidget.num, EventReactionEmojiNumWidget.color, EventReactionEmojiNumWidget.fontSize (/home/runner/work/plur/plur/lib/component/event/event_reactions_widget.dart:788:7)
Warning: ] The value of the local variable 'event' isn't used (/home/runner/work/plur/plur/lib/component/event/event_reactions_widget.dart:597:11)
na +[info] Don't use 'BuildContext's across async gaps (/home/runner/work/plur/plur/lib/component/event/event_reactions_widget.dart:496:36)
na +[info] Don't use 'BuildContext's across async gaps (/home/runner/work/plur/plur/lib/component/event/event_reactions_widget.dart:567:44)
na +[info] Don't invoke 'print' in production code (/home/runner/work/plur/plur/lib/component/event/event_reactions_widget.dart:654:7)
na +[info] Constructors for public widgets should have a named 'key' parameter (/home/runner/work/plur/plur/lib/component/event/event_reactions_widget.dart:722:3)
na +[info] Use a 'SizedBox' to add whitespace to a layout (/home/runner/work/plur/plur/lib/component/event/event_reactions_widget.dart:770:12)
na +[info] Constructors for public widgets should have a named 'key' parameter (/home/runner/work/plur/plur/lib/component/event/event_reactions_widget.dart:799:3)
na +[info] Use interpolation to compose strings and values (/home/runner/work/plur/plur/lib/component/editor/editor_mixin.dart:869:15)
na +[info] Use interpolation to compose strings and values (/home/runner/work/plur/plur/lib/component/editor/editor_mixin.dart:877:15)
na +[info] Use a 'SizedBox' to add whitespace to a layout (/home/runner/work/plur/plur/lib/component/editor/editor_mixin.dart:999:20)
na +[info] Use 'const' with the constructor to improve performance (/home/runner/work/plur/plur/lib/component/editor/editor_mixin.dart:1001:22)
na +[info] Use a 'SizedBox' to add whitespace to a layout (/home/runner/work/plur/plur/lib/component/editor/editor_mixin.dart:1051:16)
na +[info] Don't invoke 'print' in production code (/home/runner/work/plur/plur/lib/component/editor/editor_mixin.dart:1160:9)
na +[info] Use 'const' with the constructor to improve performance (/home/runner/work/plur/plur/lib/component/editor/editor_mixin.dart:1169:19)
+[info] Can't use a relative path to import a library in 'lib' (/home/runner/work/plur/plur/test/nostr_sdk/event_relation_test.dart:4:8)
+[info] Can't use a relative path to import a library in 'lib' (/home/runner/work/plur/plur/test/nostr_sdk/event_relation_test.dart:5:8)
+[info] Can't use a relative path to import a library in 'lib' (/home/runner/work/plur/plur/test/nostr_sdk/nip29/group_identifier_test.dart:2:8)
Error: No new linting errors may be merged with main.
Error: Process completed with exit code 1.
```

So for clarity, all lint errors not marked `na` above should be fixed in this PR.


## How to test

I expect the Examine Lint Errors job is going to fail on this PR for the same reason I detailed above, so I think reviewers will need to manually run `dart analyze` on the changed files and verify that none of the lint errors I claim to have fixed are still present, and no new lint errors were introduce by this PR that aren't on `main`.


## Screenshots/Video
Post screenshots or video showing your changes, ideally showing how the app worked before and after these changes. Delete this section if this PR contains no visual changes.

| Before | After |
|--------|--------|
| replaceme | replaceme |
