### PR TITLE
Disable testflight-deploy-staging on merge to main to save money

### DIFF
--- a/.github/workflows/testflight-deploy-staging.yml
+++ b/.github/workflows/testflight-deploy-staging.yml
@@ -2,9 +2,9 @@ name: TestFlight Staging Deployment
 permissions:
   contents: write  # This is needed for tag pushing
 on:
-  push:
-    branches:
-      - main
+  #push:
+  #  branches:
+  #    - main
   # Enable manual run
   workflow_dispatch:
 


### PR DESCRIPTION
## Issues covered
none

## Description
This is a temporary change to reduce our Github Actions costs. [discussion here](https://twist.com/a/238733/ch/774051/t/6837699/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the deployment workflow to disable automatic triggering from changes, ensuring releases can now be initiated manually only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->