### PR TITLE
Run TestFlight deployment at midnight

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -1,9 +1,13 @@
 name: TestFlight Release Deployment
 permissions:
   contents: write  # This is needed for tag pushing
+
 on:
   # Enable manual run
   workflow_dispatch:
+  # Scheduled build at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## Issues covered
none

## Description
A followup to #113, this runs a testflight deployment of Plur at midnight UTC once a day to cut down on the cost of our Github Actions runs.

## How to test
I think we'll just have to merge and see. I can manually trigger a build but that won't test the new schedule logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the deployment process by adding an automated daily update trigger at midnight UTC. This improvement complements manual deployment and aims to deliver updates more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->