### PR TITLE
re-enable Testflight builds on merge to main

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -3,11 +3,11 @@ permissions:
   contents: write  # This is needed for tag pushing
 
 on:
+  push:
+    branches:
+      - main
   # Enable manual run
   workflow_dispatch:
-  # Scheduled build at midnight UTC
-  schedule:
-    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## Issues covered
none

## Description
This re-enables internal TestFlight builds on merges to main. I had disabled them [here](https://github.com/verse-pbc/plur/pull/120) to save money on Github actions (more discussion in [this thread](https://twist.com/a/238733/ch/774051/t/6837699/c/94567078)).

## How to test
Merge and see if a testflight build goes out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined our deployment process to trigger automatically on updates to the main branch.
  - Removed the scheduled nightly deployment in favor of more immediate updates.
  - Retained the option to initiate deployments manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->