### PR TITLE
Bump version to 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Release Notes
+
+### Internal Changes
+
+## [0.0.4]
+
+### Release Notes
 - Fixed an issue with mentioning users in a group. [#232](https://github.com/verse-pbc/issues/issues/232)
 - Fixed issue where invite links do not work if app is not already running. [#249](https://github.com/verse-pbc/issues/issues/249)
 - Fixed an issue where the group metadata events where fetch from more groups than needed. [#273](https://github.com/verse-pbc/issues/issues/273)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## Issues covered
none

## Description
Just my bi-weekly task of bumping the version number to keep the CHANGELOG from growing indefinitely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced release notes organization by distinguishing user-visible updates from technical improvements.
- **Chores**
  - Updated the application version to 0.0.5 to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->