### PR TITLE
It/250 new notes toast broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where the group metadata events where fetch from more groups than needed. [#273](https://github.com/verse-pbc/issues/issues/273)
 - Add ability to view list of members in a group [#262](https://github.com/verse-pbc/issues/issues/262)
 - Added a warning that group media is public. [#246](https://github.com/verse-pbc/issues/issues/246)
+- Fixed issue where new notes toast was not getting displayed in groups. [#250](https://github.com/verse-pbc/issues/issues/250)
 
 ### Internal Changes
 - Fixed bundle id and provisioning profile names for staging builds. [#220](https://github.com/verse-pbc/issues/issues/220)

--- a/lib/router/group/group_detail_note_list_widget.dart
+++ b/lib/router/group/group_detail_note_list_widget.dart
@@ -159,11 +159,6 @@ class _GroupDetailNoteListWidgetState
     }, null);
   }
 
-  /// Handles events created by the current user.
-  void handleDirectEvent(Event event) {
-    groupDetailProvider?.handleDirectEvent(event);
-  }
-
   Future<void> refresh() async {
     _subscribe();
   }

--- a/lib/router/group/group_detail_note_list_widget.dart
+++ b/lib/router/group/group_detail_note_list_widget.dart
@@ -14,6 +14,7 @@ import '../../consts/base_consts.dart';
 import '../../provider/settings_provider.dart';
 import '../../util/load_more_event.dart';
 import '../../util/theme_util.dart';
+import '../../util/time_util.dart';
 import '../../provider/relay_provider.dart';
 
 class GroupDetailNoteListWidget extends StatefulWidget {
@@ -117,20 +118,21 @@ class _GroupDetailNoteListWidgetState
       _unsubscribe();
     }
 
+    final currentTime = currentUnixTimestamp();
     final filters = [
       {
         // Listen for group notes
         // Use #h tag to match how notes are created
         "kinds": [EventKind.GROUP_NOTE],
         "#h": [widget.groupIdentifier.groupId],
-        "since": DateTime.now().millisecondsSinceEpoch
+        "since": currentTime
       },
       {
         // Listen for group note replies
         // Use #h tag to match how notes are created
         "kinds": [EventKind.GROUP_NOTE_REPLY],
         "#h": [widget.groupIdentifier.groupId],
-        "since": DateTime.now().millisecondsSinceEpoch
+        "since": currentTime
       }
     ];
 


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/250

## Description
This PR fixes an issue where the new notes toast was not being displayed in groups when the current user is not the person that posted a new note.

The fix was that the currentTime used in filtering the subscription was not formatted the right way. I asked AI why it was working before and I got the reply:

> Previously, historical events were being received on initial connection, which made it appear as if real-time was working. After cache clear/reconnect, no new events could match the filter due to the timestamp being in milliseconds (year ~55000).
> 
> Nostr protocol expects Unix timestamps in seconds, while Dart's `DateTime.now().millisecondsSinceEpoch` returns milliseconds. And I needed to add proper conversion to ensure correct timestamp format.

There was a `currentUnixTimestamp` function in the codebase that someone added that was doing this already, so I just used that. I also removed an unused function.

I felt dumb not knowing this was the time format nostr was expecting. (Coderrabit, don't bother summarising this line 🙄)

## How to test
1. Navigate to a group on device A.
2. Navigate to same group on device B.
3. Post a note on device A, you should see the new notes toast appear on device B.
4. Reply to a note on device A, you should see the new notes toast appear on device B.

## Screenshots/Video
Only showing the after because the before just doesn't show any new post toast.

https://github.com/user-attachments/assets/665026b0-bde0-4bba-a7b3-71e4747f83a2


