### PR TITLE
Update confirm button disabled color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Release Notes
 - Fixed issue where new notes toast was not getting displayed in groups. [#250](https://github.com/verse-pbc/issues/issues/250)
+- Updated the confirm button disabled color. [#279](https://github.com/verse-pbc/issues/issues/279)
 
 ### Internal Changes
 

--- a/lib/component/primary_button_widget.dart
+++ b/lib/component/primary_button_widget.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:nostrmo/util/theme_util.dart';
+
+class PrimaryButtonWidget extends StatelessWidget {
+  final String text;
+  final VoidCallback? onTap;
+  final bool enabled;
+  final double height;
+  final double borderRadius;
+  const PrimaryButtonWidget({
+    super.key,
+    required this.text,
+    this.onTap,
+    this.enabled = true,
+    this.height = 40,
+    this.borderRadius = 0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    final buttonColor = themeData.customColors.accentColor;
+    final buttonTextColor = themeData.customColors.buttonTextColor;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(borderRadius),
+      child: InkWell(
+        onTap: enabled ? onTap : null,
+        highlightColor: buttonColor.withOpacity(0.2),
+        borderRadius: BorderRadius.circular(borderRadius),
+        child: Container(
+          decoration: BoxDecoration(
+            color: enabled ? buttonColor : buttonColor.withOpacity(0.4),
+            borderRadius: BorderRadius.circular(borderRadius),
+          ),
+          height: height,
+          alignment: Alignment.center,
+          child: Text(
+            text,
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color:
+                  enabled ? buttonTextColor : buttonTextColor.withOpacity(0.4),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/component/primary_button_widget.dart
+++ b/lib/component/primary_button_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nostrmo/util/theme_util.dart';
 
+/// Button used for primary actions throughout the app.
 class PrimaryButtonWidget extends StatelessWidget {
   final String text;
   final VoidCallback? onTap;

--- a/lib/router/group/create_community_widget.dart
+++ b/lib/router/group/create_community_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:nostrmo/generated/l10n.dart';
+import 'package:nostrmo/component/primary_button_widget.dart';
 
 class CreateCommunityWidget extends StatefulWidget {
   final void Function(String) onCreateCommunity;
@@ -16,8 +17,6 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return Column(
       children: [
         const Text(
@@ -41,25 +40,12 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
           },
         ),
         const SizedBox(height: 20),
-        InkWell(
+        PrimaryButtonWidget(
+          text: S.of(context).Confirm,
           onTap: _communityNameController.text.isNotEmpty
               ? () => widget.onCreateCommunity(_communityNameController.text)
               : null,
-          highlightColor: theme.primaryColor.withOpacity(0.2),
-          child: Container(
-            color: _communityNameController.text.isNotEmpty
-                ? theme.primaryColor
-                : theme.disabledColor,
-            height: 40,
-            alignment: Alignment.center,
-            child: Text(
-              S.of(context).Confirm,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                color: Colors.white,
-              ),
-            ),
-          ),
+          enabled: _communityNameController.text.isNotEmpty,
         ),
       ],
     );


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/279

## Description
This PR updates the confirm button disabled color to match what is on figma. I also used this as an opportunity to make the button a reusable component since it is widely used on figma.

## How to test
1. Navigate to the home page.
2. Tap on the create group button.
3. The button should have a 0.4 opacity if no text has been inputed in the textfield.

## Screenshots/Video

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/b1520035-9d0e-43ff-ab43-6233bcd5e95f" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/83db0762-3385-4145-8d84-a28f01c0b8fb" alt="After" width="250"/> |

@Chardot Please review these UI changes to be sure they match the design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a customizable primary button component that delivers a consistent, responsive user experience, notably enhancing interactions in community creation workflows.
- **Styles**
  - Updated the confirm button’s disabled state color to provide clearer visual feedback when the action is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->