### PR TITLE
Rename EventKind consts

### DIFF
--- a/lib/component/content/content_decoder.dart
+++ b/lib/component/content/content_decoder.dart
@@ -300,7 +300,7 @@ class ContentDecoder {
             var naddr = NIP19Tlv.decodeNaddr(key);
             if (naddr != null) {
               if (StringUtil.isNotBlank(naddr.id) &&
-                  naddr.kind == EventKind.TEXT_NOTE) {
+                  naddr.kind == EventKind.textNote) {
                 // block
                 handledStr = _closeHandledStr(handledStr, inlines);
                 _closeInlines(inlines, list, textOnTap: textOnTap);
@@ -314,7 +314,7 @@ class ContentDecoder {
                 );
                 list.add(widget);
               } else if (StringUtil.isNotBlank(naddr.author) &&
-                  naddr.kind == EventKind.METADATA) {
+                  naddr.kind == EventKind.metadata) {
                 // inline
                 handledStr = _closeHandledStr(handledStr, inlines);
                 inlines.add(ContentMentionUserWidget(pubkey: naddr.author));

--- a/lib/component/content/content_widget.dart
+++ b/lib/component/content/content_widget.dart
@@ -817,7 +817,7 @@ class _ContentWidgetState extends State<ContentWidget> {
           }
 
           if (StringUtil.isNotBlank(naddr.author) &&
-              naddr.kind == EventKind.METADATA) {
+              naddr.kind == EventKind.metadata) {
             // inline
             bufferToList(buffer, currentList, images);
             currentList.add(WidgetSpan(
@@ -846,7 +846,7 @@ class _ContentWidgetState extends State<ContentWidget> {
             counterAddLines(fakeEventCounter);
 
             return otherStr;
-          } else if (naddr.kind == EventKind.LIVE_EVENT) {
+          } else if (naddr.kind == EventKind.liveEvent) {
             bufferToList(buffer, currentList, images, removeLastSpan: true);
             var w = ContentLinkPreWidget(
               link: "https://zap.stream/$key",

--- a/lib/component/editor/editor_mixin.dart
+++ b/lib/component/editor/editor_mixin.dart
@@ -707,7 +707,7 @@ mixin EditorMixin {
       if (openPrivateDM) {
         // Private dm message
         var rumorEvent = Event(
-            nostr!.publicKey, EventKind.PRIVATE_DIRECT_MESSAGE, allTags, result,
+            nostr!.publicKey, EventKind.privateDirectMessage, allTags, result,
             createdAt: getCreatedAt());
         // this is the event send to sender, should return after send and set into giftWrapProvider and dmProvider
         event = await GiftWrapUtil.getGiftWrapEvent(
@@ -733,7 +733,7 @@ mixin EditorMixin {
         }
         result = encryptedResult;
         event = Event(
-            nostr!.publicKey, EventKind.DIRECT_MESSAGE, allTags, result,
+            nostr!.publicKey, EventKind.directMessage, allTags, result,
             createdAt: getCreatedAt());
       }
     } else if (groupIdentifier != null) {
@@ -753,13 +753,13 @@ mixin EditorMixin {
       // get poll tag from PollInputComponent
       var pollTags = pollInputController.getTags();
       allTags.addAll(pollTags);
-      event = Event(nostr!.publicKey, EventKind.POLL, allTags, result,
+      event = Event(nostr!.publicKey, EventKind.poll, allTags, result,
           createdAt: getCreatedAt());
     } else if (inputZapGoal) {
       // zap goal event
       var extralTags = zapGoalInputController.getTags();
       allTags.addAll(extralTags);
-      event = Event(nostr!.publicKey, EventKind.ZAP_GOALS, allTags, result,
+      event = Event(nostr!.publicKey, EventKind.zapGoals, allTags, result,
           createdAt: getCreatedAt());
     } else if (isLongForm()) {
       // long form
@@ -783,15 +783,15 @@ mixin EditorMixin {
       allTags.add(["d", id]);
       allTags.add([
         "a",
-        "${EventKind.LONG_FORM}:${nostr!.publicKey}:$id",
+        "${EventKind.longForm}:${nostr!.publicKey}:$id",
         oneWriteRelay
       ]);
 
-      event = Event(nostr!.publicKey, EventKind.LONG_FORM, allTags, result,
+      event = Event(nostr!.publicKey, EventKind.longForm, allTags, result,
           createdAt: getCreatedAt());
     } else {
       // text note
-      event = Event(nostr!.publicKey, EventKind.TEXT_NOTE, allTags, result,
+      event = Event(nostr!.publicKey, EventKind.textNote, allTags, result,
           createdAt: getCreatedAt());
     }
 

--- a/lib/component/event/event_list_widget.dart
+++ b/lib/component/event/event_list_widget.dart
@@ -83,7 +83,7 @@ class _EventListWidgetState extends State<EventListWidget> {
       ),
     );
 
-    if (widget.event.kind == EventKind.ZAP) {
+    if (widget.event.kind == EventKind.zap) {
       main = EventBitcoinIconWidget.wrapper(main);
     }
 
@@ -110,7 +110,7 @@ class _EventListWidgetState extends State<EventListWidget> {
   }
 
   void jumpToThread() {
-    if (widget.event.kind == EventKind.REPOST) {
+    if (widget.event.kind == EventKind.repost) {
       // try to find target event
       if (widget.event.content.contains("\"pubkey\"")) {
         try {

--- a/lib/component/event/event_main_widget.dart
+++ b/lib/component/event/event_main_widget.dart
@@ -150,8 +150,8 @@ class _EventMainWidgetState extends State<EventMainWidget> {
     var mainColor = themeData.primaryColor;
 
     Event? repostEvent;
-    if ((widget.event.kind == EventKind.REPOST ||
-            widget.event.kind == EventKind.GENERIC_REPOST) &&
+    if ((widget.event.kind == EventKind.repost ||
+            widget.event.kind == EventKind.genericRepost) &&
         widget.event.content.contains("\"pubkey\"")) {
       try {
         var jsonMap = jsonDecode(widget.event.content);
@@ -176,7 +176,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
 
     List<Widget> list = [];
     if (showWarning || !eventRelation.warning) {
-      if (widget.event.kind == EventKind.LONG_FORM) {
+      if (widget.event.kind == EventKind.longForm) {
         var longFormMargin =
             const EdgeInsets.only(bottom: Base.basePaddingHalf);
 
@@ -266,8 +266,8 @@ class _EventMainWidgetState extends State<EventMainWidget> {
           eventRelation: eventRelation,
           showDetailBtn: widget.showDetailBtn,
         ));
-      } else if (widget.event.kind == EventKind.REPOST ||
-          widget.event.kind == EventKind.GENERIC_REPOST) {
+      } else if (widget.event.kind == EventKind.repost ||
+          widget.event.kind == EventKind.genericRepost) {
         list.add(Container(
           alignment: Alignment.centerLeft,
           child: Text("${localization.Boost}:"),
@@ -310,7 +310,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
             );
           }
         }
-      } else if (widget.event.kind == EventKind.STORAGE_SHARED_FILE) {
+      } else if (widget.event.kind == EventKind.storageSharedFile) {
         list.add(buildStorageSharedFileWidget());
         if (!widget.inQuote) {
           if (eventRelation.zapInfos.isNotEmpty) {
@@ -382,11 +382,11 @@ class _EventMainWidgetState extends State<EventMainWidget> {
           buildContentWidget(settingsProvider, imagePreview, videoPreview),
         );
 
-        if (widget.event.kind == EventKind.POLL) {
+        if (widget.event.kind == EventKind.poll) {
           list.add(EventPollWidget(
             event: widget.event,
           ));
-        } else if (widget.event.kind == EventKind.ZAP_GOALS ||
+        } else if (widget.event.kind == EventKind.zapGoals ||
             StringUtil.isNotBlank(eventRelation.zapraiser)) {
           list.add(EventZapGoalsWidget(
             event: widget.event,
@@ -394,9 +394,9 @@ class _EventMainWidgetState extends State<EventMainWidget> {
           ));
         }
 
-        if (widget.event.kind == EventKind.FILE_HEADER ||
-            widget.event.kind == EventKind.VIDEO_HORIZONTAL ||
-            widget.event.kind == EventKind.VIDEO_VERTICAL) {
+        if (widget.event.kind == EventKind.fileHeader ||
+            widget.event.kind == EventKind.videoHorizontal ||
+            widget.event.kind == EventKind.videoVertical) {
           String? m;
           String? url;
           List? imeta;
@@ -440,8 +440,8 @@ class _EventMainWidgetState extends State<EventMainWidget> {
           }
 
           if (StringUtil.isNotBlank(url)) {
-            if (widget.event.kind == EventKind.VIDEO_HORIZONTAL ||
-                widget.event.kind == EventKind.VIDEO_VERTICAL) {
+            if (widget.event.kind == EventKind.videoHorizontal ||
+                widget.event.kind == EventKind.videoVertical) {
               if (settingsProvider.videoPreview == OpenStatus.OPEN &&
                   widget.showVideo) {
                 list.add(ContentVideoWidget(url: url!));
@@ -495,14 +495,14 @@ class _EventMainWidgetState extends State<EventMainWidget> {
         }
 
         if (eventRelation.aId != null &&
-            eventRelation.aId!.kind == EventKind.LONG_FORM &&
+            eventRelation.aId!.kind == EventKind.longForm &&
             widget.showLinkedLongForm) {
           list.add(EventQuoteWidget(
             aId: eventRelation.aId!,
           ));
         }
 
-        if (widget.event.kind == EventKind.TORRENTS) {
+        if (widget.event.kind == EventKind.torrents) {
           var torrentInfo = TorrentInfo.fromEvent(widget.event);
           if (torrentInfo != null) {
             list.add(EventTorrentWidget(torrentInfo));
@@ -513,8 +513,8 @@ class _EventMainWidgetState extends State<EventMainWidget> {
           list.add(buildZapInfoWidgets(themeData));
         }
 
-        if (widget.event.kind != EventKind.ZAP &&
-            !(widget.event.kind == EventKind.FILE_HEADER && widget.inQuote)) {
+        if (widget.event.kind != EventKind.zap &&
+            !(widget.event.kind == EventKind.fileHeader && widget.inQuote)) {
           list.add(EventReactionsWidget(
             screenshotController: widget.screenshotController,
             event: widget.event,
@@ -534,7 +534,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
     List<Widget> eventAllList = [];
 
     if (eventRelation.aId != null &&
-        eventRelation.aId!.kind == EventKind.COMMUNITY_DEFINITION &&
+        eventRelation.aId!.kind == EventKind.communityDefinition &&
         widget.showCommunity) {
       var communityTitle = Row(
         children: [
@@ -583,8 +583,8 @@ class _EventMainWidgetState extends State<EventMainWidget> {
     }
 
     if (!(widget.inQuote &&
-        (widget.event.kind == EventKind.FILE_HEADER ||
-            widget.event.kind == EventKind.STORAGE_SHARED_FILE))) {
+        (widget.event.kind == EventKind.fileHeader ||
+            widget.event.kind == EventKind.storageSharedFile))) {
       eventAllList.add(EventTopWidget(
         event: widget.event,
         pagePubkey: widget.pagePubkey,
@@ -616,7 +616,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
       SettingsProvider settingsProvider, bool imagePreview, bool videoPreview) {
     var content = widget.event.content;
     if (StringUtil.isBlank(content) &&
-        widget.event.kind == EventKind.ZAP &&
+        widget.event.kind == EventKind.zap &&
         StringUtil.isNotBlank(eventRelation.innerZapContent)) {
       content = eventRelation.innerZapContent!;
     }

--- a/lib/component/event/event_quote_widget.dart
+++ b/lib/component/event/event_quote_widget.dart
@@ -94,8 +94,8 @@ class _EventQuoteWidgetState extends CustState<EventQuoteWidget> {
 
   Widget buildEventWidget(
       Event event, Color cardColor, BoxDecoration boxDecoration) {
-    if (event.kind == EventKind.STORAGE_SHARED_FILE ||
-        event.kind == EventKind.FILE_HEADER) {
+    if (event.kind == EventKind.storageSharedFile ||
+        event.kind == EventKind.fileHeader) {
       return EventMainWidget(
         screenshotController: screenshotController,
         event: event,

--- a/lib/component/event/event_top_widget.dart
+++ b/lib/component/event/event_top_widget.dart
@@ -43,7 +43,7 @@ class _EventTopWidgetState extends State<EventTopWidget> {
 
     pubkey = widget.event.pubkey;
     // if this is the zap event, change the pubkey from the zap tag info
-    if (widget.event.kind == EventKind.ZAP) {
+    if (widget.event.kind == EventKind.zap) {
       for (var tag in widget.event.tags) {
         if (tag[0] == "description" && widget.event.tags.length > 1) {
           var description = tag[1];

--- a/lib/component/link_router_util.dart
+++ b/lib/component/link_router_util.dart
@@ -59,18 +59,18 @@ class LinkRouterUtil {
 
       var naddr = NIP19Tlv.decodeNaddr(key);
       if (naddr != null) {
-        if (naddr.kind == EventKind.TEXT_NOTE &&
+        if (naddr.kind == EventKind.textNote &&
             StringUtil.isNotBlank(naddr.id)) {
           var relayAddr = (naddr.relays != null && naddr.relays!.isNotEmpty)
               ? naddr.relays![0]
               : null;
           EventIdRouterWidget.router(context, naddr.id,
               relayAddr: relayAddr);
-        } else if (naddr.kind == EventKind.LONG_FORM &&
+        } else if (naddr.kind == EventKind.longForm &&
             StringUtil.isNotBlank(naddr.id)) {
           // TODO load long form
         } else if (StringUtil.isNotBlank(naddr.author) &&
-            naddr.kind == EventKind.METADATA) {
+            naddr.kind == EventKind.metadata) {
           RouterUtil.router(context, RouterPath.USER, naddr.author);
         }
       }

--- a/lib/component/user/user_badges_widget.dart
+++ b/lib/component/user/user_badges_widget.dart
@@ -95,7 +95,7 @@ class _UserBadgesWidgetState extends CustState<UserBadgesWidget>
   @override
   Future<void> onReady(BuildContext context) async {
     var filter =
-        Filter(authors: [widget.pubkey], kinds: [EventKind.BADGE_ACCEPT]);
+        Filter(authors: [widget.pubkey], kinds: [EventKind.badgeAccept]);
     nostr!.query([filter.toJson()], (event) {
       var result = eventMemBox.add(event);
       if (result) {

--- a/lib/data/event_reactions.dart
+++ b/lib/data/event_reactions.dart
@@ -84,14 +84,14 @@ class EventReactions implements FindEventInterface {
     if (eventIdMap[id] == null) {
       eventIdMap[id] = 1;
 
-      if (event.kind == EventKind.TEXT_NOTE) {
+      if (event.kind == EventKind.textNote) {
         replyNum++;
         replies.add(event);
-      } else if (event.kind == EventKind.REPOST ||
-          event.kind == EventKind.GENERIC_REPOST) {
+      } else if (event.kind == EventKind.repost ||
+          event.kind == EventKind.genericRepost) {
         repostNum++;
         reposts.add(event);
-      } else if (event.kind == EventKind.REACTION) {
+      } else if (event.kind == EventKind.reaction) {
         var likeText = getLikeText(event);
 
         var num = likeNumMap[likeText];
@@ -106,7 +106,7 @@ class EventReactions implements FindEventInterface {
           myLikeEvents ??= [];
           myLikeEvents!.add(event);
         }
-      } else if (event.kind == EventKind.ZAP) {
+      } else if (event.kind == EventKind.zap) {
         zapNum += ZapInfoUtil.getNumFromZapEvent(event);
         zaps.add(event);
 

--- a/lib/provider/badge_definition_provider.dart
+++ b/lib/provider/badge_definition_provider.dart
@@ -41,7 +41,7 @@ class BadgeDefinitionProvider extends ChangeNotifier with LaterFunction {
     List<Map<String, dynamic>> filters = [];
     for (var pubkey in _needUpdatePubKeys) {
       var filter =
-          Filter(kinds: [EventKind.BADGE_DEFINITION], authors: [pubkey]);
+          Filter(kinds: [EventKind.badgeDefinition], authors: [pubkey]);
       filters.add(filter.toJson());
     }
     var subscriptId = StringUtil.rndNameStr(16);

--- a/lib/provider/badge_provider.dart
+++ b/lib/provider/badge_provider.dart
@@ -33,7 +33,7 @@ class BadgeProvider extends ChangeNotifier {
       return;
     }
 
-    var filter = Filter(authors: [pubkey], kinds: [EventKind.BADGE_ACCEPT]);
+    var filter = Filter(authors: [pubkey], kinds: [EventKind.badgeAccept]);
     if (initQuery) {
       targetNostr!.addInitQuery([filter.toJson()], onEvent);
     } else {

--- a/lib/provider/community_approved_provider.dart
+++ b/lib/provider/community_approved_provider.dart
@@ -30,7 +30,7 @@ class CommunityApprovedProvider extends ChangeNotifier with LaterFunction {
     if (eids.isNotEmpty) {
       // load
       Map<String, dynamic> filter = {};
-      filter["kinds"] = [EventKind.COMMUNITY_APPROVED];
+      filter["kinds"] = [EventKind.communityApproved];
       List<String> ids = [];
       ids.addAll(eids);
       filter["#e"] = ids;

--- a/lib/provider/community_info_provider.dart
+++ b/lib/provider/community_info_provider.dart
@@ -46,7 +46,7 @@ class CommunityInfoProvider extends ChangeNotifier with LaterFunction {
       }
 
       var filter = Filter(
-          kinds: [EventKind.COMMUNITY_DEFINITION], authors: [aId.pubkey]);
+          kinds: [EventKind.communityDefinition], authors: [aId.pubkey]);
       var queryArg = filter.toJson();
       queryArg["#d"] = [aId.title];
       filters.add(queryArg);

--- a/lib/provider/contact_list_provider.dart
+++ b/lib/provider/contact_list_provider.dart
@@ -81,11 +81,11 @@ class ContactListProvider extends ChangeNotifier {
     targetNostr ??= nostr;
     subscriptId = StringUtil.rndNameStr(16);
     var filter = Filter(
-        kinds: [EventKind.CONTACT_LIST],
+        kinds: [EventKind.contactList],
         limit: 1,
         authors: [targetNostr!.publicKey]);
     var filter1 = Filter(
-        kinds: [EventKind.FOLLOW_SETS],
+        kinds: [EventKind.followSets],
         limit: 100,
         authors: [targetNostr.publicKey]);
     targetNostr.addInitQuery([
@@ -95,7 +95,7 @@ class ContactListProvider extends ChangeNotifier {
   }
 
   void _onEvent(Event e) async {
-    if (e.kind == EventKind.CONTACT_LIST) {
+    if (e.kind == EventKind.contactList) {
       if (_event == null || e.createdAt > _event!.createdAt) {
         _event = e;
         _contactList = ContactList.fromJson(e.tags, _event!.createdAt);
@@ -104,7 +104,7 @@ class ContactListProvider extends ChangeNotifier {
 
         relayProvider.relayUpdateByContactListEvent(e);
       }
-    } else if (e.kind == EventKind.FOLLOW_SETS) {
+    } else if (e.kind == EventKind.followSets) {
       var dTag = FollowSet.getDTag(e);
       if (dTag != null) {
         var oldFollowSet = _followSetMap[dTag];
@@ -303,13 +303,13 @@ class ContactListProvider extends ChangeNotifier {
     followSetEventMap.remove(dTag);
 
     var filter =
-        Filter(authors: [nostr!.publicKey], kinds: [EventKind.FOLLOW_SETS]);
+        Filter(authors: [nostr!.publicKey], kinds: [EventKind.followSets]);
     var filterMap = filter.toJson();
     filterMap["#d"] = [dTag];
 
     Map<String, int> deleted = {};
     nostr!.query([filterMap], (event) {
-      if (event.kind == EventKind.FOLLOW_SETS) {
+      if (event.kind == EventKind.followSets) {
         if (deleted[event.id] == null) {
           deleted[event.id] = 1;
           nostr!.deleteEvent(event.id);

--- a/lib/provider/dm_provider.dart
+++ b/lib/provider/dm_provider.dart
@@ -91,7 +91,7 @@ class DMProvider extends ChangeNotifier with PendingEventsLaterFunction {
     var keyIndex = settingsProvider.privateKeyIndex!;
     var events = await EventDB.list(
         keyIndex,
-        [EventKind.DIRECT_MESSAGE, EventKind.PRIVATE_DIRECT_MESSAGE],
+        [EventKind.directMessage, EventKind.privateDirectMessage],
         0,
         10000000);
     if (events.isNotEmpty) {
@@ -199,11 +199,11 @@ class DMProvider extends ChangeNotifier with PendingEventsLaterFunction {
       {Nostr? targetNostr, bool initQuery = false, bool queryAll = false}) {
     targetNostr ??= nostr;
     var filter0 = Filter(
-      kinds: [EventKind.DIRECT_MESSAGE],
+      kinds: [EventKind.directMessage],
       authors: [targetNostr!.publicKey],
     );
     var filter1 = Filter(
-      kinds: [EventKind.DIRECT_MESSAGE],
+      kinds: [EventKind.directMessage],
       p: [targetNostr.publicKey],
     );
 

--- a/lib/provider/event_reactions_provider.dart
+++ b/lib/provider/event_reactions_provider.dart
@@ -124,11 +124,11 @@ class EventReactionsProvider extends ChangeNotifier with WhenStopFunction {
   }
 
   List<int> supportEventKinds = [
-    EventKind.TEXT_NOTE,
-    EventKind.REPOST,
-    EventKind.GENERIC_REPOST,
-    EventKind.REACTION,
-    EventKind.ZAP
+    EventKind.textNote,
+    EventKind.repost,
+    EventKind.genericRepost,
+    EventKind.reaction,
+    EventKind.zap
   ];
 
   Future<bool> _loadFromRelayLocal(String id) async {

--- a/lib/provider/filter_provider.dart
+++ b/lib/provider/filter_provider.dart
@@ -99,9 +99,9 @@ class FilterProvider extends ChangeNotifier implements EventFilter {
     }
 
     if (EventKind.supportedEvents.contains(e.kind) ||
-        e.kind == EventKind.DIRECT_MESSAGE ||
-        e.kind == EventKind.GIFT_WRAP) {
-      if (e.kind != EventKind.ZAP_GOALS && !wotProvider.check(e.pubkey)) {
+        e.kind == EventKind.directMessage ||
+        e.kind == EventKind.giftWrap) {
+      if (e.kind != EventKind.zapGoals && !wotProvider.check(e.pubkey)) {
         return true;
       }
 

--- a/lib/provider/gift_wrap_provider.dart
+++ b/lib/provider/gift_wrap_provider.dart
@@ -12,7 +12,7 @@ class GiftWrapProvider extends ChangeNotifier {
   Future<void> init() async {
     var keyIndex = settingsProvider.privateKeyIndex!;
     var events =
-        await EventDB.list(keyIndex, [EventKind.GIFT_WRAP], 0, 10000000);
+        await EventDB.list(keyIndex, [EventKind.giftWrap], 0, 10000000);
 
     for (var event in events) {
       box.add(event);
@@ -38,7 +38,7 @@ class GiftWrapProvider extends ChangeNotifier {
     }
 
     var filter = Filter(
-      kinds: [EventKind.GIFT_WRAP],
+      kinds: [EventKind.giftWrap],
       since: since,
       p: [nostr!.publicKey],
     );
@@ -55,7 +55,7 @@ class GiftWrapProvider extends ChangeNotifier {
 
       // some event need some handle
       if (sourceEvent != null) {
-        if (sourceEvent.kind == EventKind.PRIVATE_DIRECT_MESSAGE) {
+        if (sourceEvent.kind == EventKind.privateDirectMessage) {
           // private DM, handle by dmProvider
           dmProvider.onEvent(sourceEvent);
         }

--- a/lib/provider/group_provider.dart
+++ b/lib/provider/group_provider.dart
@@ -151,7 +151,7 @@ class GroupProvider extends ChangeNotifier with LaterFunction {
   /// from the network.
   void query(GroupIdentifier groupIdentifier) {
     final groupId = groupIdentifier.groupId;
-    var metadataJsonMap = genFilter(groupId, EventKind.GROUP_METADATA);
+    var metadataJsonMap = genFilter(groupId, EventKind.groupMetadata);
     var adminsJsonMap = genFilter(groupId, EventKind.groupAdmins);
     var membersJsonMap = genFilter(groupId, EventKind.groupMembers);
     final filters = [metadataJsonMap, adminsJsonMap, membersJsonMap];
@@ -168,7 +168,7 @@ class GroupProvider extends ChangeNotifier with LaterFunction {
 
   void onEvent(GroupIdentifier groupIdentifier, Event e) {
     bool updated = false;
-    if (e.kind == EventKind.GROUP_METADATA) {
+    if (e.kind == EventKind.groupMetadata) {
       updated = handleEvent(
           groupMetadatas, groupIdentifier, GroupMetadata.loadFromEvent(e));
     } else if (e.kind == EventKind.groupAdmins) {
@@ -177,7 +177,7 @@ class GroupProvider extends ChangeNotifier with LaterFunction {
     } else if (e.kind == EventKind.groupMembers) {
       updated = handleEvent(
           groupMembers, groupIdentifier, GroupMembers.loadFromEvent(e));
-    } else if (e.kind == EventKind.GROUP_EDIT_METADATA) {
+    } else if (e.kind == EventKind.groupEditMetadata) {
       updated = handleEvent(
           groupMetadatas, groupIdentifier, GroupMetadata.loadFromEvent(e));
     }
@@ -232,7 +232,7 @@ class GroupProvider extends ChangeNotifier with LaterFunction {
       tags.add(["about", groupMetadata.about!]);
     }
 
-    var e = Event(nostr!.publicKey, EventKind.GROUP_EDIT_METADATA, tags, "");
+    var e = Event(nostr!.publicKey, EventKind.groupEditMetadata, tags, "");
     var result =
         await nostr!.sendEvent(e, tempRelays: relays, targetRelays: relays);
     if (result != null) {

--- a/lib/provider/list_provider.dart
+++ b/lib/provider/list_provider.dart
@@ -63,7 +63,7 @@ class ListProvider extends ChangeNotifier {
   }
 
   void _handleExtraAndNotify(Event event) async {
-    if (event.kind == EventKind.EMOJIS_LIST) {
+    if (event.kind == EventKind.emojisList) {
       // This is a emoji list, try to handle some listSet
       for (var tag in event.tags) {
         if (tag is List && tag.length > 1) {
@@ -74,13 +74,13 @@ class ListProvider extends ChangeNotifier {
           }
         }
       }
-    } else if (event.kind == EventKind.BOOKMARKS_LIST) {
+    } else if (event.kind == EventKind.bookmarksList) {
       // due to bookmarks info will use many times, so it should parse when it was receive.
       var bm = await parseBookmarks();
       if (bm != null) {
         _bookmarks = bm;
       }
-    } else if (event.kind == EventKind.GROUP_LIST) {
+    } else if (event.kind == EventKind.groupList) {
       _groupIdentifiers.clear();
 
       for (var tag in event.tags) {
@@ -104,7 +104,7 @@ class ListProvider extends ChangeNotifier {
   }
 
   String get emojiKey {
-    return "${EventKind.EMOJIS_LIST}:${nostr!.publicKey}";
+    return "${EventKind.emojisList}:${nostr!.publicKey}";
   }
 
   List<MapEntry<String, List<CustomEmoji>>> emojis(
@@ -169,7 +169,7 @@ class ListProvider extends ChangeNotifier {
       }
       tags.add(["emoji", emoji.name, emoji.filepath]);
       var changedEvent =
-          Event(nostr!.publicKey, EventKind.EMOJIS_LIST, tags, "");
+          Event(nostr!.publicKey, EventKind.emojisList, tags, "");
       var result = await nostr!.sendEvent(changedEvent);
 
       if (result != null) {
@@ -188,7 +188,7 @@ class ListProvider extends ChangeNotifier {
   }
 
   String get bookmarksKey {
-    return "${EventKind.BOOKMARKS_LIST}:${nostr!.publicKey}";
+    return "${EventKind.bookmarksList}:${nostr!.publicKey}";
   }
 
   Event? getBookmarksEvent() {
@@ -292,7 +292,7 @@ class ListProvider extends ChangeNotifier {
     }
 
     var event =
-        Event(nostr!.publicKey, EventKind.BOOKMARKS_LIST, tags, content!);
+        Event(nostr!.publicKey, EventKind.bookmarksList, tags, content!);
     var resultEvent = await nostr!.sendEvent(event);
     if (resultEvent != null) {
       _holder[bookmarksKey] = resultEvent;
@@ -400,7 +400,7 @@ class ListProvider extends ChangeNotifier {
 
     return Event(
       nostr!.publicKey,
-      EventKind.GROUP_JOIN,
+      EventKind.groupJoin,
       eventTags,
       "",
     );
@@ -474,7 +474,7 @@ class ListProvider extends ChangeNotifier {
 
     final event = Event(
       nostr!.publicKey,
-      EventKind.GROUP_LEAVE,
+      EventKind.groupLeave,
       [
         ["h", gi.groupId]
       ],
@@ -498,7 +498,7 @@ class ListProvider extends ChangeNotifier {
 
     final updateGroupListEvent = Event(
       nostr!.publicKey,
-      EventKind.GROUP_LIST,
+      EventKind.groupList,
       tags,
       "",
     );
@@ -519,7 +519,7 @@ class ListProvider extends ChangeNotifier {
     // We only support private closed group for now.
     final createGroupEvent = Event(
       nostr!.publicKey,
-      EventKind.GROUP_CREATE_GROUP,
+      EventKind.groupCreateGroup,
       [
         ["h", groupId]
       ],
@@ -574,7 +574,7 @@ class ListProvider extends ChangeNotifier {
 
     final inviteEvent = Event(
       nostr!.publicKey,
-      EventKind.GROUP_CREATE_INVITE,
+      EventKind.groupCreateInvite,
       tags,
       "", // Empty content as per example
     );
@@ -605,14 +605,14 @@ class ListProvider extends ChangeNotifier {
   /// Fetch metadata for a specific group
   void _queryGroupMetadata(GroupIdentifier groupId) async {
     // Create filter for group metadata
-    final filter = Filter(kinds: [EventKind.GROUP_METADATA], limit: 1);
+    final filter = Filter(kinds: [EventKind.groupMetadata], limit: 1);
     final filterMap = filter.toJson();
     filterMap["#d"] = [groupId.groupId];
 
     nostr!.query(
       [filterMap],
       (Event event) {
-        if (event.kind == EventKind.GROUP_METADATA) {
+        if (event.kind == EventKind.groupMetadata) {
           groupProvider.onEvent(groupId, event);
         }
       },
@@ -669,7 +669,7 @@ class ListProvider extends ChangeNotifier {
 
   /// Handles metadata update events by updating the group metadata in GroupProvider
   void handleEditMetadataEvent(Event event) {
-    if (event.kind == EventKind.GROUP_EDIT_METADATA) {
+    if (event.kind == EventKind.groupEditMetadata) {
       _extractGroupIdentifiersFromTags(event, tagPrefix: "h")
           .forEach((groupId) {
             groupProvider.onEvent(groupId, event);

--- a/lib/provider/mention_me_provider.dart
+++ b/lib/provider/mention_me_provider.dart
@@ -37,12 +37,12 @@ class MentionMeProvider extends ChangeNotifier
 
   List<int> queryEventKinds() {
     return [
-      EventKind.TEXT_NOTE,
-      EventKind.REPOST,
-      EventKind.BADGE_AWARD,
-      EventKind.GENERIC_REPOST,
-      EventKind.ZAP,
-      EventKind.LONG_FORM,
+      EventKind.textNote,
+      EventKind.repost,
+      EventKind.badgeAward,
+      EventKind.genericRepost,
+      EventKind.zap,
+      EventKind.longForm,
     ];
   }
 
@@ -95,7 +95,7 @@ class MentionMeProvider extends ChangeNotifier
 
   void onEvent(Event event) {
     // filter the zap send by myself.
-    if (event.kind == EventKind.ZAP) {
+    if (event.kind == EventKind.zap) {
       for (var tag in event.tags) {
         if (tag is List && tag.length > 1) {
           var k = tag[0];

--- a/lib/provider/metadata_provider.dart
+++ b/lib/provider/metadata_provider.dart
@@ -34,14 +34,14 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
       }
 
       var events = await EventDB.list(Base.defaultDataIndex,
-          [EventKind.RELAY_LIST_METADATA, EventKind.CONTACT_LIST], 0, 1000000);
+          [EventKind.relayListMetadata, EventKind.contactList], 0, 1000000);
       _metadataProvider!._contactListMap.clear();
       for (var e in events) {
-        if (e.kind == EventKind.RELAY_LIST_METADATA) {
+        if (e.kind == EventKind.relayListMetadata) {
           var relayListMetadata = RelayListMetadata.fromEvent(e);
           _metadataProvider!._relayListMetadataCache[relayListMetadata.pubkey] =
               relayListMetadata;
-        } else if (e.kind == EventKind.CONTACT_LIST) {
+        } else if (e.kind == EventKind.contactList) {
           var contactList = ContactList.fromJson(e.tags, e.createdAt);
           _metadataProvider!._contactListMap[e.pubkey] = contactList;
         }
@@ -156,7 +156,7 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
 
   void _handlePendingEvents() {
     for (var event in _pendingEvents.all()) {
-      if (event.kind == EventKind.METADATA) {
+      if (event.kind == EventKind.metadata) {
         if (StringUtil.isBlank(event.content)) {
           continue;
         }
@@ -183,7 +183,7 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
           _metadataCache[md.pubkey!] = md;
           // refresh
         }
-      } else if (event.kind == EventKind.RELAY_LIST_METADATA) {
+      } else if (event.kind == EventKind.relayListMetadata) {
         // this is relayInfoMetadata, only set to cache, not update UI
         var oldRelayListMetadata = _relayListMetadataCache[event.pubkey];
         if (oldRelayListMetadata == null) {
@@ -196,13 +196,13 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
               "delete from event where key_index = ? and kind = ? and pubkey = ?",
               [
                 Base.defaultDataIndex,
-                EventKind.RELAY_LIST_METADATA,
+                EventKind.relayListMetadata,
                 event.pubkey
               ]);
           EventDB.insert(Base.defaultDataIndex, event);
           _eventToRelayListCache(event);
         }
-      } else if (event.kind == EventKind.CONTACT_LIST) {
+      } else if (event.kind == EventKind.contactList) {
         var oldContactList = _contactListMap[event.pubkey];
         if (oldContactList == null) {
           // insert
@@ -212,7 +212,7 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
           // update, remote old event and insert new event
           EventDB.execute(
               "delete from event where key_index = ? and kind = ? and pubkey = ?",
-              [Base.defaultDataIndex, EventKind.CONTACT_LIST, event.pubkey]);
+              [Base.defaultDataIndex, EventKind.contactList, event.pubkey]);
           EventDB.insert(Base.defaultDataIndex, event);
           _eventToContactList(event);
         }
@@ -244,7 +244,7 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
       {
         var filter = Filter(
           kinds: [
-            EventKind.METADATA,
+            EventKind.metadata,
           ],
           authors: [pubkey],
           limit: 1,
@@ -254,7 +254,7 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
       {
         var filter = Filter(
           kinds: [
-            EventKind.RELAY_LIST_METADATA,
+            EventKind.relayListMetadata,
           ],
           authors: [pubkey],
           limit: 1,
@@ -264,7 +264,7 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
       {
         var filter = Filter(
           kinds: [
-            EventKind.CONTACT_LIST,
+            EventKind.contactList,
           ],
           authors: [pubkey],
           limit: 1,

--- a/lib/provider/nwc_provider.dart
+++ b/lib/provider/nwc_provider.dart
@@ -91,7 +91,7 @@ class NWCProvider extends ChangeNotifier {
     final messageType = json[0];
     if (messageType == 'EVENT' && jsonLength > 2) {
       final event = Event.fromJson(json[2]);
-      if (event.kind == EventKind.NWC_RESPONSE_EVENT) {
+      if (event.kind == EventKind.nwcResponseEvent) {
         var encryptedContent = event.content;
         var sourceConent =
             NIP04.decrypt(encryptedContent, agreement!, _nwcInfo!.pubkey);
@@ -155,7 +155,7 @@ class NWCProvider extends ChangeNotifier {
     // gen event
     var payInvoiceEvent = Event(
       _nwcInfo!.senderPubkey(),
-      EventKind.NWC_REQUEST_EVENT,
+      EventKind.nwcRequestEvent,
       [
         ["p", _nwcInfo!.pubkey]
       ],
@@ -175,7 +175,7 @@ class NWCProvider extends ChangeNotifier {
       StringUtil.rndNameStr(14),
       {
         "#e": [payInvoiceEvent.id],
-        "kinds": [EventKind.NWC_RESPONSE_EVENT],
+        "kinds": [EventKind.nwcResponseEvent],
       }
     ]);
   }

--- a/lib/provider/relay_provider.dart
+++ b/lib/provider/relay_provider.dart
@@ -164,7 +164,7 @@ class RelayProvider extends ChangeNotifier {
 
     loadRelayAddrs(contactListProvider.content);
     listProvider.load(nostr.publicKey,
-        [EventKind.BOOKMARKS_LIST, EventKind.EMOJIS_LIST, EventKind.GROUP_LIST],
+        [EventKind.bookmarksList, EventKind.emojisList, EventKind.groupList],
         targetNostr: nostr, initQuery: true);
     badgeProvider.reload(targetNostr: nostr, initQuery: true);
 

--- a/lib/provider/wot_provider.dart
+++ b/lib/provider/wot_provider.dart
@@ -71,12 +71,12 @@ class WotProvider extends ChangeNotifier {
       var filter = Filter(authors: [
         pubkey
       ], kinds: [
-        EventKind.TEXT_NOTE,
-        EventKind.DIRECT_MESSAGE,
-        EventKind.REPOST,
-        EventKind.REACTION,
-        EventKind.GENERIC_REPOST,
-        EventKind.FOLLOW_SETS,
+        EventKind.textNote,
+        EventKind.directMessage,
+        EventKind.repost,
+        EventKind.reaction,
+        EventKind.genericRepost,
+        EventKind.followSets,
       ]);
       var events = await nostr!.queryEvents([filter.toJson()],
           relayTypes: RelayType.cacheAndLocal);

--- a/lib/router/dm/dm_detail_item_widget.dart
+++ b/lib/router/dm/dm_detail_item_widget.dart
@@ -62,7 +62,7 @@ class _DMDetailItemWidgetState extends State<DMDetailItemWidget>
     }
 
     var content = widget.event.content;
-    if (widget.event.kind == EventKind.DIRECT_MESSAGE &&
+    if (widget.event.kind == EventKind.directMessage &&
         StringUtil.isBlank(plainContent)) {
       handleEncryptedText(widget.event, widget.sessionPubkey);
     }
@@ -80,7 +80,7 @@ class _DMDetailItemWidgetState extends State<DMDetailItemWidget>
       ),
     );
     Widget enhancedIcon = Container();
-    if (widget.event.kind == EventKind.PRIVATE_DIRECT_MESSAGE) {
+    if (widget.event.kind == EventKind.privateDirectMessage) {
       enhancedIcon = Container(
         margin: const EdgeInsets.only(
           left: Base.basePaddingHalf,

--- a/lib/router/dm/dm_detail_widget.dart
+++ b/lib/router/dm/dm_detail_widget.dart
@@ -229,7 +229,7 @@ class _DMDetailWidgetState extends CustState<DMDetailWidget> with EditorMixin {
   void handleDefaultPrivateDMSetting(Event? e) {
     if (!_handledDefaultPrivateDM &&
         e != null &&
-        e.kind == EventKind.PRIVATE_DIRECT_MESSAGE) {
+        e.kind == EventKind.privateDirectMessage) {
       openPrivateDM = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         updateUI();
@@ -247,9 +247,9 @@ class _DMDetailWidgetState extends CustState<DMDetailWidget> with EditorMixin {
         BotToast.showText(text: S.of(context).Send_fail);
         return;
       }
-      if (event.kind == EventKind.DIRECT_MESSAGE) {
+      if (event.kind == EventKind.directMessage) {
         dmProvider.addEventAndUpdateReadedTime(detail!, event);
-      } else if (event.kind == EventKind.GIFT_WRAP) {
+      } else if (event.kind == EventKind.giftWrap) {
         giftWrapProvider.onEvent(event);
       }
 

--- a/lib/router/dm/dm_session_list_item_widget.dart
+++ b/lib/router/dm/dm_session_list_item_widget.dart
@@ -46,7 +46,7 @@ class _DMSessionListItemWidgetState extends State<DMSessionListItemWidget>
         var dmSession = widget.detail.dmSession;
 
         var content = dmSession.newestEvent!.content;
-        if (dmSession.newestEvent!.kind == EventKind.DIRECT_MESSAGE &&
+        if (dmSession.newestEvent!.kind == EventKind.directMessage &&
             StringUtil.isBlank(plainContent)) {
           handleEncryptedText(dmSession.newestEvent!, dmSession.pubkey);
         }

--- a/lib/router/edit/editor_widget.dart
+++ b/lib/router/edit/editor_widget.dart
@@ -222,7 +222,7 @@ class _EditorWidgetState extends CustState<EditorWidget> with EditorMixin {
           if (tagName == "a") {
             // this note is add to community
             var aid = AId.fromString(tagValue);
-            if (aid != null && aid.kind == EventKind.COMMUNITY_DEFINITION) {
+            if (aid != null && aid.kind == EventKind.communityDefinition) {
               list.add(Container(
                 padding: const EdgeInsets.only(
                   left: Base.basePadding,

--- a/lib/router/event_detail/event_detail_widget.dart
+++ b/lib/router/event_detail/event_detail_widget.dart
@@ -145,14 +145,14 @@ class _EventDetailWidgetState extends State<EventDetailWidget> {
             }
 
             var event = allEvent[index - 1];
-            if (event.kind == EventKind.ZAP) {
+            if (event.kind == EventKind.zap) {
               return ZapEventListWidget(event: event);
-            } else if (event.kind == EventKind.TEXT_NOTE) {
+            } else if (event.kind == EventKind.textNote) {
               return ReactionEventListWidget(event: event, text: localization.replied);
-            } else if (event.kind == EventKind.REPOST ||
-                event.kind == EventKind.GENERIC_REPOST) {
+            } else if (event.kind == EventKind.repost ||
+                event.kind == EventKind.genericRepost) {
               return ReactionEventListWidget(event: event, text: localization.boosted);
-            } else if (event.kind == EventKind.REACTION) {
+            } else if (event.kind == EventKind.reaction) {
               return ReactionEventListWidget(
                   event: event,
                   text: "${localization.liked} ${EventReactions.getLikeText(event)}");

--- a/lib/router/follow/mention_me_widget.dart
+++ b/lib/router/follow/mention_me_widget.dart
@@ -56,10 +56,10 @@ class _MentionMeWidgetState extends KeepAliveCustState<MentionMeWidget>
       controller: _controller,
       itemBuilder: (BuildContext context, int index) {
         var event = events[index];
-        if (event.kind == EventKind.BADGE_AWARD) {
+        if (event.kind == EventKind.badgeAward) {
           return BadgeAwardWidget(event: event);
         } else {
-          if (event.kind == EventKind.ZAP) {
+          if (event.kind == EventKind.zap) {
             if (StringUtil.isBlank(event.content)) {
               var innerZapContent = EventRelation.getInnerZapContent(event);
               if (StringUtil.isBlank(innerZapContent)) {

--- a/lib/router/follow_suggest/follow_suggest_widget.dart
+++ b/lib/router/follow_suggest/follow_suggest_widget.dart
@@ -146,7 +146,7 @@ class _FollowSuggestWidgetState extends CustState<FollowSuggestWidget> {
       for (var i = 0; i < pubkeys.length && i < 10; i++) {
         var pubkey = pubkeys[i];
         var filter = Filter(kinds: [
-          EventKind.METADATA,
+          EventKind.metadata,
         ], authors: [
           pubkey
         ]);
@@ -159,7 +159,7 @@ class _FollowSuggestWidgetState extends CustState<FollowSuggestWidget> {
       for (var i = 10; i < pubkeys.length && i < 20; i++) {
         var pubkey = pubkeys[i];
         var filter = Filter(kinds: [
-          EventKind.METADATA,
+          EventKind.metadata,
         ], authors: [
           pubkey
         ]);

--- a/lib/router/globals/events/globals_events_widget.dart
+++ b/lib/router/globals/events/globals_events_widget.dart
@@ -94,7 +94,7 @@ class _GlobalsEventsWidgetState extends KeepAliveCustState<GlobalsEventsWidget>
       }
     }
 
-    var filter = Filter(ids: ids, kinds: [EventKind.TEXT_NOTE]);
+    var filter = Filter(ids: ids, kinds: [EventKind.textNote]);
     nostr!.subscribe([filter.toJson()], (event) {
       if (eventBox.isEmpty()) {
         laterTimeMS = 200;

--- a/lib/router/group/communities_widget.dart
+++ b/lib/router/group/communities_widget.dart
@@ -87,12 +87,12 @@ class _CommunitiesWidgetState extends KeepAliveCustState<CommunitiesWidget>
       },
       {
         // Listen for community deletions
-        "kinds": [EventKind.GROUP_DELETE_GROUP],
+        "kinds": [EventKind.groupDeleteGroup],
         "since": since,
       },
       {
         // Listen for community metadata edits
-        "kinds": [EventKind.GROUP_EDIT_METADATA],
+        "kinds": [EventKind.groupEditMetadata],
         "since": since,
       }
     ];
@@ -116,11 +116,11 @@ class _CommunitiesWidgetState extends KeepAliveCustState<CommunitiesWidget>
       final listProvider = Provider.of<ListProvider>(context, listen: false);
 
       switch (event.kind) {
-        case EventKind.GROUP_DELETE_GROUP:
+        case EventKind.groupDeleteGroup:
           listProvider.handleGroupDeleteEvent(event);
         case EventKind.groupMembers || EventKind.groupAdmins:
           listProvider.handleAdminMembershipEvent(event);
-        case EventKind.GROUP_EDIT_METADATA:
+        case EventKind.groupEditMetadata:
           listProvider.handleEditMetadataEvent(event);
       }
     }, null);

--- a/lib/router/profile_editor/profile_editor_widget.dart
+++ b/lib/router/profile_editor/profile_editor_widget.dart
@@ -284,7 +284,7 @@ class _ProfileEditorWidgetState extends CustState<ProfileEditorWidget> {
     }
 
     var updateEvent = Event(
-        nostr!.publicKey, EventKind.METADATA, tags, jsonEncode(metadataMap));
+        nostr!.publicKey, EventKind.metadata, tags, jsonEncode(metadataMap));
     nostr!.sendEvent(updateEvent);
 
     RouterUtil.back(context);
@@ -295,7 +295,7 @@ class _ProfileEditorWidgetState extends CustState<ProfileEditorWidget> {
   @override
   Future<void> onReady(BuildContext context) async {
     var filter = Filter(
-        kinds: [EventKind.METADATA], authors: [nostr!.publicKey], limit: 1);
+        kinds: [EventKind.metadata], authors: [nostr!.publicKey], limit: 1);
     nostr!.query([filter.toJson()], (event) {
       if (profileEvent == null) {
         profileEvent = event;

--- a/lib/router/settings/settings_widget.dart
+++ b/lib/router/settings/settings_widget.dart
@@ -640,7 +640,7 @@ class _SettingsWidgetState extends State<SettingsWidget> with WhenStopFunction {
 
         // use a blank metadata to update it
         var blankMetadata = Metadata();
-        var updateEvent = Event(nostr!.publicKey, EventKind.METADATA, [],
+        var updateEvent = Event(nostr!.publicKey, EventKind.metadata, [],
             jsonEncode(blankMetadata));
         nostr!.sendEvent(updateEvent);
 
@@ -651,9 +651,9 @@ class _SettingsWidgetState extends State<SettingsWidget> with WhenStopFunction {
         var filter = Filter(authors: [
           nostr!.publicKey
         ], kinds: [
-          EventKind.TEXT_NOTE,
-          EventKind.REPOST,
-          EventKind.GENERIC_REPOST,
+          EventKind.textNote,
+          EventKind.repost,
+          EventKind.genericRepost,
         ]);
         nostr!.query([filter.toJson()], onDeletedEventReceive);
       } catch (e) {

--- a/lib/router/thread/thread_detail_item_widget.dart
+++ b/lib/router/thread/thread_detail_item_widget.dart
@@ -39,7 +39,7 @@ class _ThreadDetailItemWidgetState extends State<ThreadDetailItemWidget> {
       sourceEventKey: widget.sourceEventKey,
     );
 
-    if (widget.item.event.kind == EventKind.ZAP) {
+    if (widget.item.event.kind == EventKind.zap) {
       main = Stack(
         children: [
           main,

--- a/lib/router/thread/thread_detail_widget.dart
+++ b/lib/router/thread/thread_detail_widget.dart
@@ -96,7 +96,7 @@ class _ThreadDetailWidgetState extends CustState<ThreadDetailWidget>
     rootId = eventRelation.rootId;
     rootEventRelayAddr = eventRelation.rootRelayAddr;
     if (eventRelation.aId != null &&
-        eventRelation.aId!.kind == EventKind.LONG_FORM) {
+        eventRelation.aId!.kind == EventKind.longForm) {
       aId = eventRelation.aId;
     }
     if (rootId == null) {
@@ -357,9 +357,9 @@ class _ThreadDetailWidgetState extends CustState<ThreadDetailWidget>
       // }
 
       List<int> replyKinds = [...EventKind.supportedEvents]
-        ..remove(EventKind.REPOST)
-        ..remove(EventKind.LONG_FORM)
-        ..add(EventKind.ZAP);
+        ..remove(EventKind.repost)
+        ..remove(EventKind.longForm)
+        ..add(EventKind.zap);
 
       // query sub events
       var filter = Filter(e: [rootId!], kinds: replyKinds);

--- a/lib/router/thread/thread_router_helper.dart
+++ b/lib/router/thread/thread_router_helper.dart
@@ -91,7 +91,7 @@ mixin ThreadRouterHelper<T extends StatefulWidget>
   void onEvent(Event event) {
     wotProvider.addTempFromEvent(event);
 
-    if (event.kind == EventKind.ZAP && StringUtil.isBlank(event.content)) {
+    if (event.kind == EventKind.zap && StringUtil.isBlank(event.content)) {
       var innerZapContent = EventRelation.getInnerZapContent(event);
       if (StringUtil.isBlank(innerZapContent)) {
         return;

--- a/lib/router/thread_trace_router/thread_trace_widget.dart
+++ b/lib/router/thread_trace_router/thread_trace_widget.dart
@@ -96,7 +96,7 @@ class _ThreadTraceWidgetState extends State<ThreadTraceWidget>
       key: sourceEventKey,
       traceMode: false,
     );
-    if (sourceEvent!.kind == EventKind.ZAP) {
+    if (sourceEvent!.kind == EventKind.zap) {
       mainEventWidget = EventBitcoinIconWidget.wrapper(mainEventWidget);
     }
 
@@ -205,14 +205,14 @@ class _ThreadTraceWidgetState extends State<ThreadTraceWidget>
     // find reply data
     AId? aId;
     if (eventRelation.aId != null &&
-        eventRelation.aId!.kind == EventKind.LONG_FORM) {
+        eventRelation.aId!.kind == EventKind.longForm) {
       aId = eventRelation.aId;
     }
 
     List<int> replyKinds = [...EventKind.supportedEvents]
-      ..remove(EventKind.REPOST)
-      ..remove(EventKind.LONG_FORM)
-      ..add(EventKind.ZAP);
+      ..remove(EventKind.repost)
+      ..remove(EventKind.longForm)
+      ..add(EventKind.zap);
 
     // query sub events
     var parentIds = [sourceEvent!.id];

--- a/lib/router/user/user_statistics_widget.dart
+++ b/lib/router/user/user_statistics_widget.dart
@@ -218,7 +218,7 @@ class _UserStatisticsWidgetState extends CustState<UserStatisticsWidget> {
       fetchLocalContactsId = StringUtil.rndNameStr(16);
       localContactBox = EventMemBox(sortAfterAdd: false);
       var filter =
-          Filter(authors: [widget.pubkey], kinds: [EventKind.CONTACT_LIST]);
+          Filter(authors: [widget.pubkey], kinds: [EventKind.contactList]);
       nostr!.query([filter.toJson()], (event) {
         localContactBox!.add(event);
       }, id: fetchLocalContactsId);
@@ -269,7 +269,7 @@ class _UserStatisticsWidgetState extends CustState<UserStatisticsWidget> {
       var filter = Filter(
           authors: [widget.pubkey],
           limit: 1,
-          kinds: [EventKind.RELAY_LIST_METADATA]);
+          kinds: [EventKind.relayListMetadata]);
       nostr!.query([filter.toJson()], (event) {
         if (((relaysEvent != null &&
                     event.createdAt > relaysEvent!.createdAt) ||
@@ -317,7 +317,7 @@ class _UserStatisticsWidgetState extends CustState<UserStatisticsWidget> {
       followedMap = {};
       // pull zap event
       Map<String, dynamic> filter = {};
-      filter["kinds"] = [EventKind.CONTACT_LIST];
+      filter["kinds"] = [EventKind.contactList];
       filter["#p"] = [widget.pubkey];
       followedSubscribeId = StringUtil.rndNameStr(12);
       nostr!.query([filter], (e) {
@@ -353,7 +353,7 @@ class _UserStatisticsWidgetState extends CustState<UserStatisticsWidget> {
     if (zapEventBox == null) {
       zapEventBox = EventMemBox(sortAfterAdd: false);
       // pull zap event
-      var filter = Filter(kinds: [EventKind.ZAP], p: [widget.pubkey]);
+      var filter = Filter(kinds: [EventKind.zap], p: [widget.pubkey]);
       zapSubscribeId = StringUtil.rndNameStr(12);
 
       nostr!.query([filter.toJson()], onZapEvent, id: zapSubscribeId);
@@ -368,7 +368,7 @@ class _UserStatisticsWidgetState extends CustState<UserStatisticsWidget> {
   }
 
   onZapEvent(Event event) {
-    if (event.kind == EventKind.ZAP && zapEventBox!.add(event)) {
+    if (event.kind == EventKind.zap && zapEventBox!.add(event)) {
       setState(() {
         zapNum = zapNum! + ZapInfoUtil.getNumFromZapEvent(event);
       });

--- a/packages/nostr_sdk/lib/event_kind.dart
+++ b/packages/nostr_sdk/lib/event_kind.dart
@@ -1,186 +1,186 @@
 /// Contains constants representing Nostr event kinds.
-/// 
-/// For more information, see: 
+///
+/// For more information, see:
 /// https://github.com/nostr-protocol/nips#event-kinds
 class EventKind {
-  /// Metadata about a user (e.g., name, picture, bio).
+  /// Kind 0 - Metadata about a user (e.g., name, picture, bio).
   static const int metadata = 0;
 
-  /// Text note (standard post or message).
+  /// Kind 1 - Text note (standard post or message).
   static const int textNote = 1;
 
-  /// Recommended relay (servers the user suggests others follow).
+  /// Kind 2 - Recommended relay (servers the user suggests others follow).
   static const int recommendServer = 2;
 
-  /// List of contacts the user follows.
+  /// Kind 3 - List of contacts the user follows.
   static const int contactList = 3;
 
-  /// Encrypted direct message to another user.
+  /// Kind 4 - Encrypted direct message to another user.
   static const int directMessage = 4;
 
-  /// Event used to delete one or more previous events.
+  /// Kind 5 - Event used to delete one or more previous events.
   static const int eventDeletion = 5;
 
-  /// Repost of another event.
+  /// Kind 6 - Repost of another event.
   static const int repost = 6;
 
-  /// Reaction to another event (e.g., like, emoji).
+  /// Kind 7 - Reaction to another event (e.g., like, emoji).
   static const int reaction = 7;
 
-  /// Awarding a badge to a user.
+  /// Kind 8 - Awarding a badge to a user.
   static const int badgeAward = 8;
 
-  /// Group chat message.
+  /// Kind 9 - Group chat message.
   static const int groupChatMessage = 9;
 
-  /// Reply in a group chat.
+  /// Kind 10 - Reply in a group chat.
   static const int groupChatReply = 10;
 
-  /// Post within a group.
+  /// Kind 11 - Post within a group.
   static const int groupNote = 11;
 
-  /// Reply to a group note.
+  /// Kind 12 - Reply to a group note.
   static const int groupNoteReply = 12;
 
-  /// Event used to finalize or seal another event.
+  /// Kind 13 - Event used to finalize or seal another event.
   static const int sealEventKind = 13;
 
-  /// Private direct message using an updated encryption scheme.
+  /// Kind 14 - Private direct message using an updated encryption scheme.
   static const int privateDirectMessage = 14;
 
-  /// Generic repost event, not tied to one kind.
+  /// Kind 16 - Generic repost event, not tied to one kind.
   static const int genericRepost = 16;
 
-  /// Special event type used to wrap other events (e.g., encryption).
+  /// Kind 1059 - Special event type used to wrap other events (e.g., encryption).
   static const int giftWrap = 1059;
 
-  /// Header describing a file.
+  /// Kind 1063 - Header describing a file.
   static const int fileHeader = 1063;
 
-  /// File shared via relay.
+  /// Kind 1064 - File shared via relay.
   static const int storageSharedFile = 1064;
 
-  /// Shared torrent information.
+  /// Kind 2003 - Shared torrent information.
   static const int torrents = 2003;
 
-  /// A post that was approved by a community.
+  /// Kind 4550 - A post that was approved by a community.
   static const int communityApproved = 4550;
 
-  /// Poll event for voting.
+  /// Kind 6969 - Poll event for voting.
   static const int poll = 6969;
 
-  /// Event to add a user to a group.
+  /// Kind 9000 - Event to add a user to a group.
   static const int groupAddUser = 9000;
 
-  /// Event to remove a user from a group.
+  /// Kind 9001 - Event to remove a user from a group.
   static const int groupRemoveUser = 9001;
 
-  /// Event to edit group metadata.
+  /// Kind 9002 - Event to edit group metadata.
   static const int groupEditMetadata = 9002;
 
-  /// Add permission to a group role.
+  /// Kind 9003 - Add permission to a group role.
   static const int groupAddPermission = 9003;
 
-  /// Remove permission from a group role.
+  /// Kind 9004 - Remove permission from a group role.
   static const int groupRemovePermission = 9004;
 
-  /// Delete an event within a group.
+  /// Kind 9005 - Delete an event within a group.
   static const int groupDeleteEvent = 9005;
 
-  /// Change the status of a group (active, archived, etc).
+  /// Kind 9006 - Change the status of a group (active, archived, etc).
   static const int groupEditStatus = 9006;
 
-  /// Create a new group.
+  /// Kind 9007 - Create a new group.
   static const int groupCreateGroup = 9007;
 
-  /// Delete an existing group.
+  /// Kind 9008 - Delete an existing group.
   static const int groupDeleteGroup = 9008;
 
-  /// Create an invite to join a group.
+  /// Kind 9009 - Create an invite to join a group.
   static const int groupCreateInvite = 9009;
 
-  /// Event for joining a group.
+  /// Kind 9021 - Event for joining a group.
   static const int groupJoin = 9021;
 
-  /// Event for leaving a group.
+  /// Kind 9022 - Event for leaving a group.
   static const int groupLeave = 9022;
 
-  /// Zap goal event (e.g., fund-raising goal).
+  /// Kind 9041 - Zap goal event (e.g., fund-raising goal).
   static const int zapGoals = 9041;
 
-  /// Zap request (used to initiate zaps).
+  /// Kind 9734 - Zap request (used to initiate zaps).
   static const int zapRequest = 9734;
 
-  /// Zap payment receipt.
+  /// Kind 9735 - Zap payment receipt.
   static const int zap = 9735;
 
-  /// List of relays the user uses.
+  /// Kind 10002 - List of relays the user uses.
   static const int relayListMetadata = 10002;
 
-  /// List of bookmarks saved by the user.
+  /// Kind 10003 - List of bookmarks saved by the user.
   static const int bookmarksList = 10003;
 
-  /// List of groups the user is in or manages.
+  /// Kind 10009 - List of groups the user is in or manages.
   static const int groupList = 10009;
 
-  /// Custom emoji definitions.
+  /// Kind 10030 - Custom emoji definitions.
   static const int emojisList = 10030;
 
-  /// NWC (Nostr Wallet Connect) info event.
+  /// Kind 13194 - NWC (Nostr Wallet Connect) info event.
   static const int nwcInfoEvent = 13194;
 
-  /// Authentication event (used in NIP-42).
+  /// Kind 22242 - Authentication event (used in NIP-42).
   static const int authentication = 22242;
 
-  /// NWC request event (e.g., send zap).
+  /// Kind 23194 - NWC request event (e.g., send zap).
   static const int nwcRequestEvent = 23194;
 
-  /// NWC response event (result of request).
+  /// Kind 23195 - NWC response event (result of request).
   static const int nwcResponseEvent = 23195;
 
-  /// Event for remote signing via Nostr.
+  /// Kind 24133 - Event for remote signing via Nostr.
   static const int nostrRemoteSigning = 24133;
 
-  /// Blossom protocol HTTP authentication.
+  /// Kind 24242 - Blossom protocol HTTP authentication.
   static const int blossomHttpAuth = 24242;
 
-  /// HTTP authentication used in browser/relay login.
+  /// Kind 27235 - HTTP authentication used in browser/relay login.
   static const int httpAuth = 27235;
 
-  /// Follow sets (curated or grouped follows).
+  /// Kind 30000 - Follow sets (curated or grouped follows).
   static const int followSets = 30000;
 
-  /// Event to accept a badge.
+  /// Kind 30008 - Event to accept a badge.
   static const int badgeAccept = 30008;
 
-  /// Definition of a badge.
+  /// Kind 30009 - Definition of a badge.
   static const int badgeDefinition = 30009;
 
-  /// Long-form content (e.g., articles).
+  /// Kind 30023 - Long-form content (e.g., articles).
   static const int longForm = 30023;
 
-  /// Link long-form to another event.
+  /// Kind 30024 - Link long-form to another event.
   static const int longFormLinked = 30024;
 
-  /// Live event announcement (e.g., stream).
+  /// Kind 30311 - Live event announcement (e.g., stream).
   static const int liveEvent = 30311;
 
-  /// Community definition and settings.
+  /// Kind 34550 - Community definition and settings.
   static const int communityDefinition = 34550;
 
-  /// Horizontal video content.
+  /// Kind 34235 - Horizontal video content.
   static const int videoHorizontal = 34235;
 
-  /// Vertical video content (e.g., short videos).
+  /// Kind 34236 - Vertical video content (e.g., short videos).
   static const int videoVertical = 34236;
 
-  /// Group metadata for display or management.
+  /// Kind 39000 - Group metadata for display or management.
   static const int groupMetadata = 39000;
 
-  /// List of group admins.
+  /// Kind 39001 - List of group admins.
   static const int groupAdmins = 39001;
 
-  /// List of group members.
+  /// Kind 39002 - List of group members.
   static const int groupMembers = 39002;
 
   /// Event kinds that should not be sent to cache relays.

--- a/packages/nostr_sdk/lib/event_kind.dart
+++ b/packages/nostr_sdk/lib/event_kind.dart
@@ -1,125 +1,189 @@
+/// Contains constants representing Nostr event kinds.
+/// 
+/// For more information, see: 
+/// https://github.com/nostr-protocol/nips#event-kinds
 class EventKind {
-  static const int METADATA = 0;
+  /// Metadata about a user (e.g., name, picture, bio).
+  static const int metadata = 0;
 
-  static const int TEXT_NOTE = 1;
+  /// Text note (standard post or message).
+  static const int textNote = 1;
 
-  static const int RECOMMEND_SERVER = 2;
+  /// Recommended relay (servers the user suggests others follow).
+  static const int recommendServer = 2;
 
-  static const int CONTACT_LIST = 3;
+  /// List of contacts the user follows.
+  static const int contactList = 3;
 
-  static const int DIRECT_MESSAGE = 4;
+  /// Encrypted direct message to another user.
+  static const int directMessage = 4;
 
-  static const int EVENT_DELETION = 5;
+  /// Event used to delete one or more previous events.
+  static const int eventDeletion = 5;
 
-  static const int REPOST = 6;
+  /// Repost of another event.
+  static const int repost = 6;
 
-  static const int REACTION = 7;
+  /// Reaction to another event (e.g., like, emoji).
+  static const int reaction = 7;
 
-  static const int BADGE_AWARD = 8;
+  /// Awarding a badge to a user.
+  static const int badgeAward = 8;
 
+  /// Group chat message.
   static const int groupChatMessage = 9;
 
+  /// Reply in a group chat.
   static const int groupChatReply = 10;
 
+  /// Post within a group.
   static const int groupNote = 11;
 
+  /// Reply to a group note.
   static const int groupNoteReply = 12;
 
-  static const int SEAL_EVENT_KIND = 13;
+  /// Event used to finalize or seal another event.
+  static const int sealEventKind = 13;
 
-  static const int PRIVATE_DIRECT_MESSAGE = 14;
+  /// Private direct message using an updated encryption scheme.
+  static const int privateDirectMessage = 14;
 
-  static const int GENERIC_REPOST = 16;
+  /// Generic repost event, not tied to one kind.
+  static const int genericRepost = 16;
 
-  static const int GIFT_WRAP = 1059;
+  /// Special event type used to wrap other events (e.g., encryption).
+  static const int giftWrap = 1059;
 
-  static const int FILE_HEADER = 1063;
+  /// Header describing a file.
+  static const int fileHeader = 1063;
 
-  static const int STORAGE_SHARED_FILE = 1064;
+  /// File shared via relay.
+  static const int storageSharedFile = 1064;
 
-  static const int TORRENTS = 2003;
+  /// Shared torrent information.
+  static const int torrents = 2003;
 
-  static const int COMMUNITY_APPROVED = 4550;
+  /// A post that was approved by a community.
+  static const int communityApproved = 4550;
 
-  static const int POLL = 6969;
+  /// Poll event for voting.
+  static const int poll = 6969;
 
-  static const int GROUP_ADD_USER = 9000;
+  /// Event to add a user to a group.
+  static const int groupAddUser = 9000;
 
-  static const int GROUP_REMOVE_USER = 9001;
+  /// Event to remove a user from a group.
+  static const int groupRemoveUser = 9001;
 
-  static const int GROUP_EDIT_METADATA = 9002;
+  /// Event to edit group metadata.
+  static const int groupEditMetadata = 9002;
 
-  static const int GROUP_ADD_PERMISSION = 9003;
+  /// Add permission to a group role.
+  static const int groupAddPermission = 9003;
 
-  static const int GROUP_REMOVE_PERMISSION = 9004;
+  /// Remove permission from a group role.
+  static const int groupRemovePermission = 9004;
 
-  static const int GROUP_DELETE_EVENT = 9005;
+  /// Delete an event within a group.
+  static const int groupDeleteEvent = 9005;
 
-  static const int GROUP_EDIT_STATUS = 9006;
+  /// Change the status of a group (active, archived, etc).
+  static const int groupEditStatus = 9006;
 
-  static const int GROUP_CREATE_GROUP = 9007;
+  /// Create a new group.
+  static const int groupCreateGroup = 9007;
 
-   static const int GROUP_DELETE_GROUP = 9008;
+  /// Delete an existing group.
+  static const int groupDeleteGroup = 9008;
 
-  static const int GROUP_CREATE_INVITE = 9009;
+  /// Create an invite to join a group.
+  static const int groupCreateInvite = 9009;
 
-  static const int GROUP_JOIN = 9021;
+  /// Event for joining a group.
+  static const int groupJoin = 9021;
 
-  static const int GROUP_LEAVE = 9022;
+  /// Event for leaving a group.
+  static const int groupLeave = 9022;
 
-  static const int ZAP_GOALS = 9041;
+  /// Zap goal event (e.g., fund-raising goal).
+  static const int zapGoals = 9041;
 
-  static const int ZAP_REQUEST = 9734;
+  /// Zap request (used to initiate zaps).
+  static const int zapRequest = 9734;
 
-  static const int ZAP = 9735;
+  /// Zap payment receipt.
+  static const int zap = 9735;
 
-  static const int RELAY_LIST_METADATA = 10002;
+  /// List of relays the user uses.
+  static const int relayListMetadata = 10002;
 
-  static const int BOOKMARKS_LIST = 10003;
+  /// List of bookmarks saved by the user.
+  static const int bookmarksList = 10003;
 
-  static const int GROUP_LIST = 10009;
+  /// List of groups the user is in or manages.
+  static const int groupList = 10009;
 
-  static const int EMOJIS_LIST = 10030;
+  /// Custom emoji definitions.
+  static const int emojisList = 10030;
 
-  static const int NWC_INFO_EVENT = 13194;
+  /// NWC (Nostr Wallet Connect) info event.
+  static const int nwcInfoEvent = 13194;
 
-  static const int AUTHENTICATION = 22242;
+  /// Authentication event (used in NIP-42).
+  static const int authentication = 22242;
 
-  static const int NWC_REQUEST_EVENT = 23194;
+  /// NWC request event (e.g., send zap).
+  static const int nwcRequestEvent = 23194;
 
-  static const int NWC_RESPONSE_EVENT = 23195;
+  /// NWC response event (result of request).
+  static const int nwcResponseEvent = 23195;
 
+  /// Event for remote signing via Nostr.
   static const int nostrRemoteSigning = 24133;
 
-  static const int BLOSSOM_HTTP_AUTH = 24242;
+  /// Blossom protocol HTTP authentication.
+  static const int blossomHttpAuth = 24242;
 
-  static const int HTTP_AUTH = 27235;
+  /// HTTP authentication used in browser/relay login.
+  static const int httpAuth = 27235;
 
-  static const int FOLLOW_SETS = 30000;
+  /// Follow sets (curated or grouped follows).
+  static const int followSets = 30000;
 
-  static const int BADGE_ACCEPT = 30008;
+  /// Event to accept a badge.
+  static const int badgeAccept = 30008;
 
-  static const int BADGE_DEFINITION = 30009;
+  /// Definition of a badge.
+  static const int badgeDefinition = 30009;
 
-  static const int LONG_FORM = 30023;
+  /// Long-form content (e.g., articles).
+  static const int longForm = 30023;
 
-  static const int LONG_FORM_LINKED = 30024;
+  /// Link long-form to another event.
+  static const int longFormLinked = 30024;
 
-  static const int LIVE_EVENT = 30311;
+  /// Live event announcement (e.g., stream).
+  static const int liveEvent = 30311;
 
-  static const int COMMUNITY_DEFINITION = 34550;
+  /// Community definition and settings.
+  static const int communityDefinition = 34550;
 
-  static const int VIDEO_HORIZONTAL = 34235;
+  /// Horizontal video content.
+  static const int videoHorizontal = 34235;
 
-  static const int VIDEO_VERTICAL = 34236;
+  /// Vertical video content (e.g., short videos).
+  static const int videoVertical = 34236;
 
-  static const int GROUP_METADATA = 39000;
+  /// Group metadata for display or management.
+  static const int groupMetadata = 39000;
 
+  /// List of group admins.
   static const int groupAdmins = 39001;
 
+  /// List of group members.
   static const int groupMembers = 39002;
 
-  // avoid to send these events to cache relay
+  /// Event kinds that should not be sent to cache relays.
   static List<int> cacheAvoidEvents = [
     nostrRemoteSigning,
     groupAdmins,
@@ -130,17 +194,18 @@ class EventKind {
     groupNoteReply,
   ];
 
+  /// Event kinds currently supported in the application.
   static List<int> supportedEvents = [
-    TEXT_NOTE,
-    REPOST,
-    GENERIC_REPOST,
-    LONG_FORM,
-    FILE_HEADER,
-    STORAGE_SHARED_FILE,
-    TORRENTS,
-    POLL,
-    ZAP_GOALS,
-    VIDEO_HORIZONTAL,
-    VIDEO_VERTICAL,
+    textNote,
+    repost,
+    genericRepost,
+    longForm,
+    fileHeader,
+    storageSharedFile,
+    torrents,
+    poll,
+    zapGoals,
+    videoHorizontal,
+    videoVertical,
   ];
 }

--- a/packages/nostr_sdk/lib/event_relation.dart
+++ b/packages/nostr_sdk/lib/event_relation.dart
@@ -125,7 +125,7 @@ class EventRelation {
               zapInfos.add(zapInfo);
             }
 
-          case "description" when event.kind == EventKind.ZAP:
+          case "description" when event.kind == EventKind.zap:
             innerZapContent = SpiderUtil.subUntil(value, '"content":"', '",');
 
           case "imeta":

--- a/packages/nostr_sdk/lib/nip172/community_info.dart
+++ b/packages/nostr_sdk/lib/nip172/community_info.dart
@@ -23,7 +23,7 @@ class CommunityInfo {
   });
 
   static CommunityInfo? fromEvent(Event event) {
-    if (event.kind == EventKind.COMMUNITY_DEFINITION) {
+    if (event.kind == EventKind.communityDefinition) {
       String title = "";
       String description = "";
       String image = "";
@@ -44,7 +44,7 @@ class CommunityInfo {
 
       if (StringUtil.isNotBlank(title)) {
         var id = AId(
-            kind: EventKind.COMMUNITY_DEFINITION,
+            kind: EventKind.communityDefinition,
             pubkey: event.pubkey,
             title: title);
         return CommunityInfo(

--- a/packages/nostr_sdk/lib/nip29/nip29.dart
+++ b/packages/nostr_sdk/lib/nip29/nip29.dart
@@ -9,7 +9,7 @@ class NIP29 {
     var relays = [groupIdentifier.host];
     var event = Event(
         nostr.publicKey,
-        EventKind.GROUP_DELETE_EVENT,
+        EventKind.groupDeleteEvent,
         [
           ["h", groupIdentifier.groupId],
           ["e", eventId]
@@ -42,7 +42,7 @@ class NIP29 {
     }
 
     var relays = [groupIdentifier.host];
-    var event = Event(nostr.publicKey, EventKind.GROUP_EDIT_STATUS, tags, "");
+    var event = Event(nostr.publicKey, EventKind.groupEditStatus, tags, "");
     await nostr.sendEvent(event, tempRelays: relays, targetRelays: relays);
   }
 
@@ -51,7 +51,7 @@ class NIP29 {
     var relays = [groupIdentifier.host];
     var event = Event(
         nostr.publicKey,
-        EventKind.GROUP_ADD_USER,
+        EventKind.groupAddUser,
         [
           ["h", groupIdentifier.groupId],
           ["p", pubkey]
@@ -65,7 +65,7 @@ class NIP29 {
     var relays = [groupIdentifier.host];
     var event = Event(
         nostr.publicKey,
-        EventKind.GROUP_REMOVE_USER,
+        EventKind.groupRemoveUser,
         [
           ["h", groupIdentifier.groupId],
           ["p", pubkey]

--- a/packages/nostr_sdk/lib/nip51/follow_set.dart
+++ b/packages/nostr_sdk/lib/nip51/follow_set.dart
@@ -161,7 +161,7 @@ class FollowSet extends ContactList {
       return null;
     }
 
-    return Event(pubkey, EventKind.FOLLOW_SETS, tags, content!);
+    return Event(pubkey, EventKind.followSets, tags, content!);
   }
 
   List<Contact> get publicContacts {

--- a/packages/nostr_sdk/lib/nip58/badge_definition.dart
+++ b/packages/nostr_sdk/lib/nip58/badge_definition.dart
@@ -28,7 +28,7 @@ class BadgeDefinition {
     String? image;
     String? thumb;
 
-    if (event.kind == kind.EventKind.BADGE_DEFINITION) {
+    if (event.kind == kind.EventKind.badgeDefinition) {
       for (var tag in event.tags) {
         if (tag.length > 1) {
           var key = tag[0];

--- a/packages/nostr_sdk/lib/nip58/nip58.dart
+++ b/packages/nostr_sdk/lib/nip58/nip58.dart
@@ -25,7 +25,7 @@ class NIP58 {
     tags.add(eList);
 
     var newEvent =
-        Event(nostr.publicKey, EventKind.BADGE_ACCEPT, tags, content);
+        Event(nostr.publicKey, EventKind.badgeAccept, tags, content);
 
     return await nostr.sendEvent(newEvent);
   }

--- a/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
+++ b/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
@@ -46,7 +46,7 @@ class GiftWrapUtil {
       return null;
     }
     var sealEvent = Event(
-        targetNostr.publicKey, EventKind.SEAL_EVENT_KIND, [], sealEventContent);
+        targetNostr.publicKey, EventKind.sealEventKind, [], sealEventContent);
     targetNostr.signEvent(sealEvent);
 
     var randomPrivateKey = generatePrivateKey();
@@ -56,7 +56,7 @@ class GiftWrapUtil {
         await NIP44V2.encrypt(jsonEncode(sealEvent.toJson()), randomKey);
     var giftWrapEvent = Event(
         randomPubkey,
-        EventKind.GIFT_WRAP,
+        EventKind.giftWrap,
         [
           ["p", receiverPublicKey]
         ],

--- a/packages/nostr_sdk/lib/nip65/nip65.dart
+++ b/packages/nostr_sdk/lib/nip65/nip65.dart
@@ -23,7 +23,7 @@ class NIP65 {
       tags.add(tag);
     }
 
-    var e = Event(nostr.publicKey, EventKind.RELAY_LIST_METADATA, tags, "");
+    var e = Event(nostr.publicKey, EventKind.relayListMetadata, tags, "");
     nostr.sendEvent(e);
   }
 }

--- a/packages/nostr_sdk/lib/nip65/relay_list_metadata.dart
+++ b/packages/nostr_sdk/lib/nip65/relay_list_metadata.dart
@@ -18,7 +18,7 @@ class RelayListMetadata {
     // relays = [];
     readAbleRelays = [];
     writeAbleRelays = [];
-    if (event.kind == EventKind.RELAY_LIST_METADATA) {
+    if (event.kind == EventKind.relayListMetadata) {
       for (var tag in event.tags) {
         if (tag is List && tag.length > 1) {
           var k = tag[0];

--- a/packages/nostr_sdk/lib/nostr.dart
+++ b/packages/nostr_sdk/lib/nostr.dart
@@ -41,7 +41,7 @@ class Nostr {
 
     Event event = Event(
         _publicKey,
-        EventKind.REACTION,
+        EventKind.reaction,
         [
           ["e", id]
         ],
@@ -54,7 +54,7 @@ class Nostr {
       {List<String>? tempRelays, List<String>? targetRelays}) async {
     Event event = Event(
         _publicKey,
-        EventKind.EVENT_DELETION,
+        EventKind.eventDeletion,
         [
           ["e", eventId]
         ],
@@ -70,7 +70,7 @@ class Nostr {
       tags.add(["e", eventId]);
     }
 
-    Event event = Event(_publicKey, EventKind.EVENT_DELETION, tags, "delete");
+    Event event = Event(_publicKey, EventKind.eventDeletion, tags, "delete");
     return await sendEvent(event,
         tempRelays: tempRelays, targetRelays: targetRelays);
   }
@@ -84,7 +84,7 @@ class Nostr {
     if (StringUtil.isNotBlank(relayAddr)) {
       tag.add(relayAddr);
     }
-    Event event = Event(_publicKey, EventKind.REPOST, [tag], content);
+    Event event = Event(_publicKey, EventKind.repost, [tag], content);
     return await sendEvent(event,
         tempRelays: tempRelays, targetRelays: targetRelays);
   }
@@ -92,7 +92,7 @@ class Nostr {
   Future<Event?> sendContactList(ContactList contacts, String content,
       {List<String>? tempRelays, List<String>? targetRelays}) async {
     final tags = contacts.toJson();
-    final event = Event(_publicKey, EventKind.CONTACT_LIST, tags, content);
+    final event = Event(_publicKey, EventKind.contactList, tags, content);
     return await sendEvent(event,
         tempRelays: tempRelays, targetRelays: targetRelays);
   }

--- a/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -279,7 +279,7 @@ class RelayPool {
         ["challenge", challenge]
       ];
       Event? event =
-          Event(localNostr.publicKey, EventKind.AUTHENTICATION, tags, "");
+          Event(localNostr.publicKey, EventKind.authentication, tags, "");
       event = await localNostr.nostrSigner.signEvent(event);
       if (event != null) {
         final json = event.toJson();

--- a/packages/nostr_sdk/lib/relay_local/relay_local_mixin.dart
+++ b/packages/nostr_sdk/lib/relay_local/relay_local_mixin.dart
@@ -40,7 +40,7 @@ mixin RelayLocalMixin {
     final eventKind = event["kind"];
     final pubkey = event["pubkey"];
     switch (eventKind) {
-      case EventKind.EVENT_DELETION:
+      case EventKind.eventDeletion:
         final tags = event["tags"];
         if (tags is List && tags.isNotEmpty) {
           for (var tag in tags) {
@@ -55,8 +55,8 @@ mixin RelayLocalMixin {
             }
           }
         }
-      case EventKind.METADATA:
-      case EventKind.CONTACT_LIST:
+      case EventKind.metadata:
+      case EventKind.contactList:
         // These eventkinds can only save 1 event, so delete other event first.
         getRelayLocalDB().deleteEventByKind(pubkey, eventKind);
         continue addEvent;

--- a/packages/nostr_sdk/lib/signer/signer_test.dart
+++ b/packages/nostr_sdk/lib/signer/signer_test.dart
@@ -35,7 +35,7 @@ Future<void> signerTest(NostrSigner nostrSigner) async {
 
   await Future.delayed(const Duration(seconds: 10));
 
-  Event? event = Event(pubkey!, EventKind.TEXT_NOTE, [], "Hello");
+  Event? event = Event(pubkey!, EventKind.textNote, [], "Hello");
   event = await nostrSigner.signEvent(event);
   log(event.toString());
   log(jsonEncode(event!.toJson()));

--- a/packages/nostr_sdk/lib/upload/blossom_uploader.dart
+++ b/packages/nostr_sdk/lib/upload/blossom_uploader.dart
@@ -81,7 +81,7 @@ class BlossomUploader {
     tags.add(["size", "$fileSize"]);
     tags.add(["x", payload]);
     var nip98Event = Event(
-        nostr.publicKey, EventKind.BLOSSOM_HTTP_AUTH, tags, "Upload $fileName");
+        nostr.publicKey, EventKind.blossomHttpAuth, tags, "Upload $fileName");
     nostr.signEvent(nip98Event);
     headers["Authorization"] =
         "Nostr ${base64Url.encode(utf8.encode(jsonEncode(nip98Event.toJson())))}";

--- a/packages/nostr_sdk/lib/upload/nip95_uploader.dart
+++ b/packages/nostr_sdk/lib/upload/nip95_uploader.dart
@@ -57,7 +57,7 @@ class NIP95Uploader {
 
     var pubkey = nostr.publicKey;
     var event =
-        Event(pubkey, EventKind.STORAGE_SHARED_FILE, tags, base64Content);
+        Event(pubkey, EventKind.storageSharedFile, tags, base64Content);
 
     return nostr.sendEvent(event);
   }

--- a/packages/nostr_sdk/lib/upload/nip96_uploader.dart
+++ b/packages/nostr_sdk/lib/upload/nip96_uploader.dart
@@ -81,7 +81,7 @@ class NIP96Uploader {
       if (StringUtil.isNotBlank(payload)) {
         tags.add(["payload", payload]);
       }
-      var nip98Event = Event(nostr.publicKey, EventKind.HTTP_AUTH, tags, "");
+      var nip98Event = Event(nostr.publicKey, EventKind.httpAuth, tags, "");
 
       await nostr.signEvent(nip98Event);
 

--- a/packages/nostr_sdk/lib/zap/zap.dart
+++ b/packages/nostr_sdk/lib/zap/zap.dart
@@ -104,7 +104,7 @@ class Zap {
       tags.add(["poll_option", pollOption!]);
     }
     Event? event =
-        Event(targetNostr.publicKey, EventKind.ZAP_REQUEST, tags, eventContent);
+        Event(targetNostr.publicKey, EventKind.zapRequest, tags, eventContent);
     event = await targetNostr.nostrSigner.signEvent(event);
     if (event == null) {
       return null;

--- a/packages/nostr_sdk/lib/zap/zap_info_util.dart
+++ b/packages/nostr_sdk/lib/zap/zap_info_util.dart
@@ -34,7 +34,7 @@ class ZapInfoUtil {
   }
 
   static int getNumFromZapEvent(Event event) {
-    if (event.kind == EventKind.ZAP) {
+    if (event.kind == EventKind.zap) {
       for (var tag in event.tags) {
         if (tag.length > 1) {
           var tagType = tag[0] as String;

--- a/packages/nostr_sdk/test/event_relation_test.dart
+++ b/packages/nostr_sdk/test/event_relation_test.dart
@@ -144,7 +144,7 @@ void main() {
     test('processes description tag for zap event', () {
       var testEvent = Event.create(
         pubkey: TestData.alicePubkey,
-        kind: EventKind.ZAP,
+        kind: EventKind.zap,
         tags: [
           ['description', '{"content":"inner zap content","other":"value"}']
         ],


### PR DESCRIPTION
This PR just change EventKind const to lower camel case so they are in line with Dart style guides and also add comments explaining what each one is. I did this because I seldom need to go back to that file just to see what exact event kind number is. This improves that because we will have the event kind numbers in the symbol document window.

The `event_kind.dart` file now looks:

```dart
/// Contains constants representing Nostr event kinds.
///
/// For more information, see:
/// https://github.com/nostr-protocol/nips#event-kinds
class EventKind {
  /// Kind 0 - Metadata about a user (e.g., name, picture, bio).
  static const int metadata = 0;

  /// Kind 1 - Text note (standard post or message).
  static const int textNote = 1;

  ...

```