### PR TITLE
refactor: rename Metadata to User for clarity #275

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Admin Panel. [#263](https://github.com/verse-pbc/issues/issues/263)
 
 ### Internal Changes
+- Renamed Metadata to User for clarity. [#275](https://github.com/verse-pbc/issues/issues/275)
 
 ## [0.0.4]
 

--- a/lib/component/content/content_mention_user_widget.dart
+++ b/lib/component/content/content_mention_user_widget.dart
@@ -3,7 +3,7 @@ import 'package:nostrmo/component/user/simple_name_widget.dart';
 import 'package:provider/provider.dart';
 
 import '../../consts/router_path.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../provider/metadata_provider.dart';
 import '../../util/router_util.dart';
 import 'content_str_link_widget.dart';
@@ -22,10 +22,10 @@ class ContentMentionUserWidget extends StatefulWidget {
 class _ContentMentionUserWidgetState extends State<ContentMentionUserWidget> {
   @override
   Widget build(BuildContext context) {
-    return Selector<MetadataProvider, Metadata?>(
-      builder: (context, metadata, child) {
+    return Selector<MetadataProvider, User?>(
+      builder: (context, user, child) {
         String name =
-            SimpleNameWidget.getSimpleName(widget.pubkey, metadata);
+            SimpleNameWidget.getSimpleName(widget.pubkey, user);
 
         return ContentStrLinkWidget(
           str: "@$name",
@@ -36,7 +36,7 @@ class _ContentMentionUserWidgetState extends State<ContentMentionUserWidget> {
         );
       },
       selector: (_, provider) {
-        return provider.getMetadata(widget.pubkey);
+        return provider.getUser(widget.pubkey);
       },
     );
   }

--- a/lib/component/content/content_mention_user_widget.dart
+++ b/lib/component/content/content_mention_user_widget.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 
 import '../../consts/router_path.dart';
 import '../../data/user.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../../util/router_util.dart';
 import 'content_str_link_widget.dart';
 
@@ -22,7 +22,7 @@ class ContentMentionUserWidget extends StatefulWidget {
 class _ContentMentionUserWidgetState extends State<ContentMentionUserWidget> {
   @override
   Widget build(BuildContext context) {
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
       builder: (context, user, child) {
         String name =
             SimpleNameWidget.getSimpleName(widget.pubkey, user);

--- a/lib/component/content/content_widget.dart
+++ b/lib/component/content/content_widget.dart
@@ -810,7 +810,7 @@ class _ContentWidgetState extends State<ContentWidget> {
                   : null;
           if (StringUtil.isBlank(eventRelayAddr) && widget.event != null) {
             var ownerReadRelays =
-                metadataProvider.getExtralRelays(widget.event!.pubkey, false);
+                userProvider.getExtralRelays(widget.event!.pubkey, false);
             if (ownerReadRelays.isNotEmpty) {
               eventRelayAddr = ownerReadRelays.first;
             }

--- a/lib/component/editor/editor_mixin.dart
+++ b/lib/component/editor/editor_mixin.dart
@@ -613,7 +613,7 @@ mixin EditorMixin {
             result += "nostr:${Nip19.encodePubKey(value)} ";
 
             // add user's read relays
-            extralRelays.addAll(metadataProvider.getExtralRelays(value, false));
+            extralRelays.addAll(userProvider.getExtralRelays(value, false));
             continue;
           }
 
@@ -833,7 +833,7 @@ mixin EditorMixin {
         var k = tag[0];
         var p = tag[1];
         if (k == "p") {
-          list.addAll(metadataProvider.getExtralRelays(p, false));
+          list.addAll(userProvider.getExtralRelays(p, false));
         }
       }
     }
@@ -851,7 +851,7 @@ mixin EditorMixin {
         var k = tag[0];
         var p = tag[1];
         if (k == "p") {
-          list.addAll(metadataProvider.getExtralRelays(p, false));
+          list.addAll(userProvider.getExtralRelays(p, false));
         }
       }
     }

--- a/lib/component/editor/gen_lnbc_widget.dart
+++ b/lib/component/editor/gen_lnbc_widget.dart
@@ -7,7 +7,7 @@ import 'package:provider/provider.dart';
 
 import '../../consts/base.dart';
 import '../../consts/router_path.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
 import '../../provider/metadata_provider.dart';
@@ -37,16 +37,16 @@ class _GenLnbcWidgetState extends State<GenLnbcWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Selector<MetadataProvider, Metadata?>(
-      builder: (context, metadata, child) {
+    return Selector<MetadataProvider, User?>(
+      builder: (context, user, child) {
         final themeData = Theme.of(context);
         Color cardColor = themeData.cardColor;
         var mainColor = themeData.primaryColor;
         var titleFontSize = themeData.textTheme.bodyLarge!.fontSize;
         final localization = S.of(context);
-        if (metadata == null ||
-            (StringUtil.isBlank(metadata.lud06) &&
-                StringUtil.isBlank(metadata.lud16))) {
+        if (user == null ||
+            (StringUtil.isBlank(user.lud06) &&
+                StringUtil.isBlank(user.lud16))) {
           return Center(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -63,7 +63,7 @@ class _GenLnbcWidgetState extends State<GenLnbcWidget> {
                     str: localization.Add_now,
                     onTap: () async {
                       await RouterUtil.router(
-                          context, RouterPath.PROFILE_EDITOR, metadata);
+                          context, RouterPath.PROFILE_EDITOR, user);
                       metadataProvider.update(nostr!.publicKey);
                     },
                   ),
@@ -122,7 +122,7 @@ class _GenLnbcWidgetState extends State<GenLnbcWidget> {
             decoration: BoxDecoration(color: mainColor),
             child: InkWell(
               onTap: () {
-                _onConfirm(metadata.pubkey!);
+                _onConfirm(user.pubkey!);
               },
               highlightColor: mainColor.withOpacity(0.2),
               child: Container(
@@ -156,7 +156,7 @@ class _GenLnbcWidgetState extends State<GenLnbcWidget> {
         return main;
       },
       selector: (_, provider) {
-        return provider.getMetadata(nostr!.publicKey);
+        return provider.getUser(nostr!.publicKey);
       },
     );
   }

--- a/lib/component/editor/gen_lnbc_widget.dart
+++ b/lib/component/editor/gen_lnbc_widget.dart
@@ -10,7 +10,7 @@ import '../../consts/router_path.dart';
 import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../../util/router_util.dart';
 import '../../util/zap_action.dart';
 import '../content/content_str_link_widget.dart';
@@ -37,7 +37,7 @@ class _GenLnbcWidgetState extends State<GenLnbcWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
       builder: (context, user, child) {
         final themeData = Theme.of(context);
         Color cardColor = themeData.cardColor;
@@ -64,7 +64,7 @@ class _GenLnbcWidgetState extends State<GenLnbcWidget> {
                     onTap: () async {
                       await RouterUtil.router(
                           context, RouterPath.PROFILE_EDITOR, user);
-                      metadataProvider.update(nostr!.publicKey);
+                      userProvider.update(nostr!.publicKey);
                     },
                   ),
                 )

--- a/lib/component/editor/search_mention_user_widget.dart
+++ b/lib/component/editor/search_mention_user_widget.dart
@@ -8,7 +8,7 @@ import '../../consts/base.dart';
 import '../../data/user.dart';
 import '../../main.dart';
 import '../../provider/group_provider.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../../util/router_util.dart';
 import 'search_mention_widget.dart';
 
@@ -59,11 +59,11 @@ class _SearchMentionUserWidgetState extends State<SearchMentionUserWidget> {
     });
 
     // Load metadata for each member
-    final metadataProvider = Provider.of<MetadataProvider>(context, listen: false);
+    final userProvider = Provider.of<UserProvider>(context, listen: false);
     for (int i = 0; i < memberPubkeys.length; i++) {
       final pubkey = memberPubkeys[i];
 
-      User? initialUser = metadataProvider.getUser(pubkey);
+      User? initialUser = userProvider.getUser(pubkey);
       if (initialUser != null) {
         _allUsers[i] = initialUser;
       }
@@ -122,8 +122,8 @@ class _SearchMentionUserWidgetState extends State<SearchMentionUserWidget> {
     if (text == null || text.isEmpty) {
       _users = _allUsers.whereType<User>().toList();
     } else {
-      final metadataProvider = Provider.of<MetadataProvider>(context, listen: false);
-      _users = metadataProvider.findUser(text, limit: searchMemLimit);
+      final userProvider = Provider.of<UserProvider>(context, listen: false);
+      _users = userProvider.findUser(text, limit: searchMemLimit);
     }
 
     setState(() {});

--- a/lib/component/editor/zap_split_input_widget.dart
+++ b/lib/component/editor/zap_split_input_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/component/editor/zap_split_input_item_widget.dart';
-import 'package:nostrmo/component/user/metadata_top_widget.dart';
+import 'package:nostrmo/component/user/user_top_widget.dart';
 import 'package:nostrmo/main.dart';
 
 import '../../consts/base.dart';

--- a/lib/component/editor/zap_split_input_widget.dart
+++ b/lib/component/editor/zap_split_input_widget.dart
@@ -97,7 +97,7 @@ class _ZapSplitInputWidgetState extends State<ZapSplitInputWidget> {
 
     if (StringUtil.isNotBlank(pubkey)) {
       String relay = "";
-      var relayListMetadata = metadataProvider.getRelayListMetadata(pubkey!);
+      var relayListMetadata = userProvider.getRelayListMetadata(pubkey!);
       if (relayListMetadata != null &&
           relayListMetadata.writeAbleRelays.isNotEmpty) {
         relay = relayListMetadata.writeAbleRelays.first;

--- a/lib/component/event/event_main_widget.dart
+++ b/lib/component/event/event_main_widget.dart
@@ -17,7 +17,7 @@ import 'package:screenshot/screenshot.dart';
 import '../../consts/base.dart';
 import '../../consts/base_consts.dart';
 import '../../consts/router_path.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
 import '../../provider/metadata_provider.dart';
@@ -836,8 +836,8 @@ class _EventMainWidgetState extends State<EventMainWidget> {
     for (var zapInfo in eventRelation.zapInfos) {
       userWidgetList.add(Container(
         margin: const EdgeInsets.only(left: Base.basePaddingHalf),
-        child: Selector<MetadataProvider, Metadata?>(
-          builder: (context, metadata, child) {
+        child: Selector<MetadataProvider, User?>(
+          builder: (context, user, child) {
             return GestureDetector(
               onTap: () {
                 RouterUtil.router(context, RouterPath.USER, zapInfo.pubkey);
@@ -849,13 +849,13 @@ class _EventMainWidgetState extends State<EventMainWidget> {
                 child: UserPicWidget(
                   pubkey: zapInfo.pubkey,
                   width: imgSize,
-                  metadata: metadata,
+                  user: user,
                 ),
               ),
             );
           },
           selector: (buildContext, provider) {
-            return provider.getMetadata(zapInfo.pubkey);
+            return provider.getUser(zapInfo.pubkey);
           },
         ),
       ));
@@ -894,13 +894,13 @@ class _EventReplyingComponent extends State<EventReplyingComponent> {
       onTap: () {
         RouterUtil.router(context, RouterPath.USER, widget.pubkey);
       },
-      child: Selector<MetadataProvider, Metadata?>(
-        builder: (context, metadata, child) {
+      child: Selector<MetadataProvider, User?>(
+        builder: (context, user, child) {
           final themeData = Theme.of(context);
           var hintColor = themeData.hintColor;
           var smallTextSize = themeData.textTheme.bodySmall!.fontSize;
           var displayName =
-              SimpleNameWidget.getSimpleName(widget.pubkey, metadata);
+              SimpleNameWidget.getSimpleName(widget.pubkey, user);
 
           return Text(
             displayName,
@@ -911,7 +911,7 @@ class _EventReplyingComponent extends State<EventReplyingComponent> {
           );
         },
         selector: (_, provider) {
-          return provider.getMetadata(widget.pubkey);
+          return provider.getUser(widget.pubkey);
         },
       ),
     );

--- a/lib/component/event/event_main_widget.dart
+++ b/lib/component/event/event_main_widget.dart
@@ -20,7 +20,7 @@ import '../../consts/router_path.dart';
 import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../../provider/settings_provider.dart';
 import '../../util/router_util.dart';
 import '../confirm_dialog.dart';
@@ -836,7 +836,7 @@ class _EventMainWidgetState extends State<EventMainWidget> {
     for (var zapInfo in eventRelation.zapInfos) {
       userWidgetList.add(Container(
         margin: const EdgeInsets.only(left: Base.basePaddingHalf),
-        child: Selector<MetadataProvider, User?>(
+        child: Selector<UserProvider, User?>(
           builder: (context, user, child) {
             return GestureDetector(
               onTap: () {
@@ -894,7 +894,7 @@ class _EventReplyingComponent extends State<EventReplyingComponent> {
       onTap: () {
         RouterUtil.router(context, RouterPath.USER, widget.pubkey);
       },
-      child: Selector<MetadataProvider, User?>(
+      child: Selector<UserProvider, User?>(
         builder: (context, user, child) {
           final themeData = Theme.of(context);
           var hintColor = themeData.hintColor;

--- a/lib/component/event/event_reactions_widget.dart
+++ b/lib/component/event/event_reactions_widget.dart
@@ -616,7 +616,7 @@ class _EventReactionsWidgetState extends State<EventReactionsWidget> {
 
     relayAddrs ??= [];
     relayAddrs
-        .addAll(metadataProvider.getExtralRelays(widget.event.pubkey, false));
+        .addAll(userProvider.getExtralRelays(widget.event.pubkey, false));
 
     if (myLikeEvents == null || myLikeEvents!.isEmpty) {
       // like

--- a/lib/component/event/event_top_widget.dart
+++ b/lib/component/event/event_top_widget.dart
@@ -10,7 +10,7 @@ import 'package:nostrmo/util/router_util.dart';
 import 'package:provider/provider.dart';
 
 import '../../consts/base.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../provider/metadata_provider.dart';
 import '../nip05_valid_widget.dart';
 
@@ -56,21 +56,21 @@ class _EventTopWidgetState extends State<EventTopWidget> {
       }
     }
 
-    return Selector<MetadataProvider, Metadata?>(
+    return Selector<MetadataProvider, User?>(
       shouldRebuild: (previous, next) {
         return previous != next;
       },
       selector: (context, metadataProvider) {
-        return metadataProvider.getMetadata(pubkey!);
+        return metadataProvider.getUser(pubkey!);
       },
-      builder: (context, metadata, child) {
+      builder: (context, user, child) {
         final themeData = Theme.of(context);
 
         String nip05Text = Nip19.encodeSimplePubKey(pubkey!);
 
-        if (metadata != null) {
-          if (StringUtil.isNotBlank(metadata.nip05)) {
-            nip05Text = metadata.nip05!;
+        if (user != null) {
+          if (StringUtil.isNotBlank(user.nip05)) {
+            nip05Text = user.nip05!;
           }
         }
 
@@ -88,7 +88,7 @@ class _EventTopWidgetState extends State<EventTopWidget> {
                 child: UserPicWidget(
                   width: IMAGE_WIDTH,
                   pubkey: pubkey!,
-                  metadata: metadata,
+                  user: user,
                 ),
               )),
               Expanded(
@@ -104,7 +104,7 @@ class _EventTopWidgetState extends State<EventTopWidget> {
                             child: jumpWrap(
                               NameWidget(
                                 pubkey: widget.event.pubkey,
-                                metadata: metadata,
+                                user: user,
                                 maxLines: 1,
                                 textOverflow: TextOverflow.ellipsis,
                                 showNip05: false,

--- a/lib/component/event/event_top_widget.dart
+++ b/lib/component/event/event_top_widget.dart
@@ -11,7 +11,7 @@ import 'package:provider/provider.dart';
 
 import '../../consts/base.dart';
 import '../../data/user.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../nip05_valid_widget.dart';
 
 class EventTopWidget extends StatefulWidget {
@@ -56,12 +56,12 @@ class _EventTopWidgetState extends State<EventTopWidget> {
       }
     }
 
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
       shouldRebuild: (previous, next) {
         return previous != next;
       },
-      selector: (context, metadataProvider) {
-        return metadataProvider.getUser(pubkey!);
+      selector: (context, userProvider) {
+        return userProvider.getUser(pubkey!);
       },
       builder: (context, user, child) {
         final themeData = Theme.of(context);

--- a/lib/component/event/reaction_event_metadata_widget.dart
+++ b/lib/component/event/reaction_event_metadata_widget.dart
@@ -4,7 +4,7 @@ import 'package:nostrmo/consts/router_path.dart';
 import 'package:nostrmo/util/router_util.dart';
 import 'package:provider/provider.dart';
 
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../provider/metadata_provider.dart';
 import '../user/simple_name_widget.dart';
 
@@ -26,16 +26,16 @@ class _ReactionEventMetadataWidgetState extends State<ReactionEventMetadataWidge
 
   @override
   Widget build(BuildContext context) {
-    return Selector<MetadataProvider, Metadata?>(
-        builder: (context, metadata, child) {
+    return Selector<MetadataProvider, User?>(
+        builder: (context, user, child) {
       List<Widget> list = [];
 
-      var name = SimpleNameWidget.getSimpleName(widget.pubkey, metadata);
+      var name = SimpleNameWidget.getSimpleName(widget.pubkey, user);
 
       list.add(UserPicWidget(
         pubkey: widget.pubkey,
         width: IMAGE_WIDTH,
-        metadata: metadata,
+        user: user,
       ));
 
       list.add(Container(
@@ -58,7 +58,7 @@ class _ReactionEventMetadataWidgetState extends State<ReactionEventMetadataWidge
         ),
       );
     }, selector: (_, provider) {
-      return provider.getMetadata(widget.pubkey);
+      return provider.getUser(widget.pubkey);
     });
   }
 }

--- a/lib/component/event/reaction_event_metadata_widget.dart
+++ b/lib/component/event/reaction_event_metadata_widget.dart
@@ -5,7 +5,7 @@ import 'package:nostrmo/util/router_util.dart';
 import 'package:provider/provider.dart';
 
 import '../../data/user.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../user/simple_name_widget.dart';
 
 class ReactionEventMetadataWidget extends StatefulWidget {
@@ -26,7 +26,7 @@ class _ReactionEventMetadataWidgetState extends State<ReactionEventMetadataWidge
 
   @override
   Widget build(BuildContext context) {
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
         builder: (context, user, child) {
       List<Widget> list = [];
 

--- a/lib/component/music/blank_link_music_info_builder.dart
+++ b/lib/component/music/blank_link_music_info_builder.dart
@@ -15,10 +15,10 @@ class BlankLinkMusicInfoBuilder extends MusicInfoBuilder {
     if (StringUtil.isNotBlank(eventId)) {
       var event = singleEventProvider.getEvent(eventId!);
       if (event != null) {
-        var metadata = metadataProvider.getMetadata(event.pubkey);
-        if (metadata != null) {
-          imageUrl = metadata.picture;
-          name = metadata.name;
+        final user = metadataProvider.getUser(event.pubkey);
+        if (user != null) {
+          imageUrl = user.picture;
+          name = user.name;
         }
       }
     }

--- a/lib/component/music/blank_link_music_info_builder.dart
+++ b/lib/component/music/blank_link_music_info_builder.dart
@@ -15,7 +15,7 @@ class BlankLinkMusicInfoBuilder extends MusicInfoBuilder {
     if (StringUtil.isNotBlank(eventId)) {
       var event = singleEventProvider.getEvent(eventId!);
       if (event != null) {
-        final user = metadataProvider.getUser(event.pubkey);
+        final user = userProvider.getUser(event.pubkey);
         if (user != null) {
           imageUrl = user.picture;
           name = user.name;

--- a/lib/component/nip05_valid_widget.dart
+++ b/lib/component/nip05_valid_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../consts/nip05status.dart';
-import '../provider/metadata_provider.dart';
+import '../provider/user_provider.dart';
 
 class Nip05ValidWidget extends StatefulWidget {
   String pubkey;
@@ -22,7 +22,7 @@ class _Nip05ValidWidgetState extends State<Nip05ValidWidget> {
     var mainColor = themeData.primaryColor;
     var smallTextSize = themeData.textTheme.bodySmall!.fontSize;
 
-    return Selector<MetadataProvider, int>(
+    return Selector<UserProvider, int>(
         builder: (context, nip05Status, child) {
       var iconData = Icons.check_circle;
       if (nip05Status == Nip05Status.NIP05_NOT_FOUND ||

--- a/lib/component/placeholder/metadata_top_placeholder.dart
+++ b/lib/component/placeholder/metadata_top_placeholder.dart
@@ -4,7 +4,7 @@ import 'package:nostrmo/util/table_mode_util.dart';
 
 import '../../consts/base.dart';
 import '../../main.dart';
-import '../user/metadata_top_widget.dart';
+import '../user/user_top_widget.dart';
 
 class MetadataTopPlaceholderWidget extends StatelessWidget {
   static const double IMAGE_BORDER = 4;
@@ -24,7 +24,7 @@ class MetadataTopPlaceholderWidget extends StatelessWidget {
     var bannerHeight = maxWidth / 3;
     if (TableModeUtil.isTableMode()) {
       bannerHeight =
-          MetadataTopWidget.getPcBannerHeight(mediaDataCache.size.height);
+          UserTopWidget.getPcBannerHeight(mediaDataCache.size.height);
     }
     var textSize = themeData.textTheme.bodyMedium!.fontSize;
 

--- a/lib/component/qrcode_dialog.dart
+++ b/lib/component/qrcode_dialog.dart
@@ -5,9 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/component/user/name_widget.dart';
-import 'package:nostrmo/component/user/metadata_top_widget.dart';
+import 'package:nostrmo/component/user/user_top_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:pretty_qr_code/pretty_qr_code.dart';
 import 'package:provider/provider.dart';
 import 'package:screenshot/screenshot.dart';
@@ -56,17 +56,17 @@ class _QrcodeDialog extends State<QrcodeDialog> {
 
     List<Widget> list = [];
     var nip19Pubkey = Nip19.encodePubKey(widget.pubkey);
-    Widget topWidget = Selector<MetadataProvider, Metadata?>(
-      builder: (context, metadata, child) {
+    Widget topWidget = Selector<MetadataProvider, User?>(
+      builder: (context, user, child) {
         Widget userImageWidget = UserPicWidget(
           pubkey: widget.pubkey,
           width: IMAGE_WIDTH,
-          metadata: metadata,
+          user: user,
         );
 
         Widget userNameWidget = NameWidget(
           pubkey: widget.pubkey,
-          metadata: metadata,
+          user: user,
         );
 
         return Container(
@@ -91,7 +91,7 @@ class _QrcodeDialog extends State<QrcodeDialog> {
         );
       },
       selector: (content, provider) {
-        return provider.getMetadata(widget.pubkey);
+        return provider.getUser(widget.pubkey);
       },
     );
     list.add(topWidget);

--- a/lib/component/qrcode_dialog.dart
+++ b/lib/component/qrcode_dialog.dart
@@ -15,7 +15,7 @@ import 'package:share_plus/share_plus.dart';
 
 import '../consts/base.dart';
 import '../generated/l10n.dart';
-import '../provider/metadata_provider.dart';
+import '../provider/user_provider.dart';
 import '../util/router_util.dart';
 import '../util/store_util.dart';
 import '../util/theme_util.dart';
@@ -56,7 +56,7 @@ class _QrcodeDialog extends State<QrcodeDialog> {
 
     List<Widget> list = [];
     var nip19Pubkey = Nip19.encodePubKey(widget.pubkey);
-    Widget topWidget = Selector<MetadataProvider, User?>(
+    Widget topWidget = Selector<UserProvider, User?>(
       builder: (context, user, child) {
         Widget userImageWidget = UserPicWidget(
           pubkey: widget.pubkey,

--- a/lib/component/user/follow_btn_widget.dart
+++ b/lib/component/user/follow_btn_widget.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 import '../../main.dart';
 import '../../provider/contact_list_provider.dart';
 import '../follow_set_follow_bottom_sheet.dart';
-import 'metadata_top_widget.dart';
+import 'user_top_widget.dart';
 
 class FollowBtnWidget extends StatefulWidget {
   String pubkey;

--- a/lib/component/user/name_widget.dart
+++ b/lib/component/user/name_widget.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/component/nip05_valid_widget.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 
 class NameWidget extends StatefulWidget {
   String pubkey;
 
-  Metadata? metadata;
+  User? user;
 
   bool showNip05;
 
@@ -23,7 +23,7 @@ class NameWidget extends StatefulWidget {
   NameWidget({
     super.key,
     required this.pubkey,
-    this.metadata,
+    this.user,
     this.showNip05 = true,
     this.fontSize,
     this.fontColor,
@@ -46,7 +46,7 @@ class _NameWidgetState extends State<NameWidget> {
     var textSize = themeData.textTheme.bodyMedium!.fontSize;
     var smallTextSize = themeData.textTheme.bodySmall!.fontSize;
     Color hintColor = themeData.hintColor;
-    var metadata = widget.metadata;
+    var user = widget.user;
     String nip19Name = Nip19.encodeSimplePubKey(widget.pubkey);
     String displayName = "";
     String name = "";
@@ -54,14 +54,14 @@ class _NameWidgetState extends State<NameWidget> {
       hintColor = widget.fontColor!;
     }
 
-    if (metadata != null) {
-      if (StringUtil.isNotBlank(metadata.displayName)) {
-        displayName = metadata.displayName!;
-        if (StringUtil.isNotBlank(metadata.name)) {
-          name = metadata.name!;
+    if (user != null) {
+      if (StringUtil.isNotBlank(user.displayName)) {
+        displayName = user.displayName!;
+        if (StringUtil.isNotBlank(user.name)) {
+          name = user.name!;
         }
-      } else if (StringUtil.isNotBlank(metadata.name)) {
-        displayName = metadata.name!;
+      } else if (StringUtil.isNotBlank(user.name)) {
+        displayName = user.name!;
       }
     }
 

--- a/lib/component/user/simple_name_widget.dart
+++ b/lib/component/user/simple_name_widget.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/provider/metadata_provider.dart';
 import 'package:provider/provider.dart';
 
 class SimpleNameWidget extends StatefulWidget {
-  static String getSimpleName(String pubkey, Metadata? metadata) {
+  static String getSimpleName(String pubkey, User? user) {
     String? name;
-    if (metadata != null) {
-      if (StringUtil.isNotBlank(metadata.displayName)) {
-        name = metadata.displayName;
-      } else if (StringUtil.isNotBlank(metadata.name)) {
-        name = metadata.name;
+    if (user != null) {
+      if (StringUtil.isNotBlank(user.displayName)) {
+        name = user.displayName;
+      } else if (StringUtil.isNotBlank(user.name)) {
+        name = user.name;
       }
     }
     if (StringUtil.isBlank(name)) {
@@ -23,7 +23,7 @@ class SimpleNameWidget extends StatefulWidget {
 
   String pubkey;
 
-  Metadata? metadata;
+  User? user;
 
   TextStyle? textStyle;
 
@@ -33,7 +33,7 @@ class SimpleNameWidget extends StatefulWidget {
 
   SimpleNameWidget({super.key, 
     required this.pubkey,
-    this.metadata,
+    this.user,
     this.textStyle,
     this.maxLines,
     this.textOverflow,
@@ -48,20 +48,20 @@ class SimpleNameWidget extends StatefulWidget {
 class _SimpleNameWidgetState extends State<SimpleNameWidget> {
   @override
   Widget build(BuildContext context) {
-    if (widget.metadata != null) {
-      return buildWidget(widget.metadata);
+    if (widget.user != null) {
+      return buildWidget(widget.user);
     }
 
-    return Selector<MetadataProvider, Metadata?>(
-        builder: (context, metadata, child) {
-      return buildWidget(metadata);
+    return Selector<MetadataProvider, User?>(
+        builder: (context, user, child) {
+      return buildWidget(user);
     }, selector: (_, provider) {
-      return provider.getMetadata(widget.pubkey);
+      return provider.getUser(widget.pubkey);
     });
   }
 
-  Widget buildWidget(Metadata? metadata) {
-    var name = SimpleNameWidget.getSimpleName(widget.pubkey, metadata);
+  Widget buildWidget(User? user) {
+    var name = SimpleNameWidget.getSimpleName(widget.pubkey, user);
     return Text(
       name,
       style: widget.textStyle,

--- a/lib/component/user/simple_name_widget.dart
+++ b/lib/component/user/simple_name_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/data/user.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import 'package:provider/provider.dart';
 
 class SimpleNameWidget extends StatefulWidget {
@@ -52,7 +52,7 @@ class _SimpleNameWidgetState extends State<SimpleNameWidget> {
       return buildWidget(widget.user);
     }
 
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
         builder: (context, user, child) {
       return buildWidget(user);
     }, selector: (_, provider) {

--- a/lib/component/user/simple_user_widget.dart
+++ b/lib/component/user/simple_user_widget.dart
@@ -4,33 +4,33 @@ import 'package:nostrmo/component/user/follow_btn_widget.dart';
 import 'package:nostrmo/component/user/name_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/consts/base.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/provider/metadata_provider.dart';
 import 'package:provider/provider.dart';
 
 import '../image_widget.dart';
 
-class SimpleMetadataWidget extends StatefulWidget {
+class SimpleUserWidget extends StatefulWidget {
   String pubkey;
 
-  Metadata? metadata;
+  User? user;
 
   bool showFollow;
 
-  SimpleMetadataWidget({
+  SimpleUserWidget({
     super.key,
     required this.pubkey,
-    this.metadata,
+    this.user,
     this.showFollow = false,
   });
 
   @override
   State<StatefulWidget> createState() {
-    return _SimpleMetadataWidgetState();
+    return _SimpleUserWidgetState();
   }
 }
 
-class _SimpleMetadataWidgetState extends State<SimpleMetadataWidget> {
+class _SimpleUserWidgetState extends State<SimpleUserWidget> {
   static const double IMAGE_WIDTH = 50;
 
   static const double HEIGHT = 64;
@@ -38,32 +38,32 @@ class _SimpleMetadataWidgetState extends State<SimpleMetadataWidget> {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    if (widget.metadata != null) {
-      return buildWidget(themeData, widget.metadata!);
+    if (widget.user != null) {
+      return buildWidget(themeData, widget.user!);
     }
 
-    return Selector<MetadataProvider, Metadata?>(
-        builder: (context, metadata, child) {
-      if (metadata == null) {
+    return Selector<MetadataProvider, User?>(
+        builder: (context, user, child) {
+      if (user == null) {
         return Container(
           height: HEIGHT,
           color: themeData.hintColor,
         );
       }
 
-      return buildWidget(themeData, metadata);
+      return buildWidget(themeData, user);
     }, selector: (context, provider) {
-      return provider.getMetadata(widget.pubkey);
+      return provider.getUser(widget.pubkey);
     });
   }
 
-  Widget buildWidget(ThemeData themeData, Metadata metadata) {
+  Widget buildWidget(ThemeData themeData, User user) {
     var cardColor = themeData.cardColor;
 
     Widget? bannerImage;
-    if (StringUtil.isNotBlank(metadata.banner)) {
+    if (StringUtil.isNotBlank(user.banner)) {
       bannerImage = ImageWidget(
-        imageUrl: metadata.banner!,
+        imageUrl: user.banner!,
         width: double.maxFinite,
         height: HEIGHT,
         fit: BoxFit.fitWidth,
@@ -79,7 +79,7 @@ class _SimpleMetadataWidgetState extends State<SimpleMetadataWidget> {
       child: UserPicWidget(
         pubkey: widget.pubkey,
         width: IMAGE_WIDTH,
-        metadata: metadata,
+        user: user,
       ),
     );
 
@@ -95,8 +95,8 @@ class _SimpleMetadataWidgetState extends State<SimpleMetadataWidget> {
           children: [
             userImageWidget,
             NameWidget(
-              pubkey: metadata.pubkey!,
-              metadata: metadata,
+              pubkey: user.pubkey!,
+              user: user,
             ),
           ],
         ),

--- a/lib/component/user/simple_user_widget.dart
+++ b/lib/component/user/simple_user_widget.dart
@@ -5,7 +5,7 @@ import 'package:nostrmo/component/user/name_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/consts/base.dart';
 import 'package:nostrmo/data/user.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import 'package:provider/provider.dart';
 
 import '../image_widget.dart';
@@ -42,7 +42,7 @@ class _SimpleUserWidgetState extends State<SimpleUserWidget> {
       return buildWidget(themeData, widget.user!);
     }
 
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
         builder: (context, user, child) {
       if (user == null) {
         return Container(

--- a/lib/component/user/user_metadata_widget.dart
+++ b/lib/component/user/user_metadata_widget.dart
@@ -3,14 +3,14 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/component/content/content_widget.dart';
 
 import '../../consts/base.dart';
-import '../../data/metadata.dart';
-import 'metadata_top_widget.dart';
+import '../../data/user.dart';
+import 'user_top_widget.dart';
 import 'user_badges_widget.dart';
 
-class MetadataWidget extends StatefulWidget {
+class UserMetadataWidget extends StatefulWidget {
   String pubkey;
 
-  Metadata? metadata;
+  User? user;
 
   bool jumpable;
 
@@ -18,9 +18,9 @@ class MetadataWidget extends StatefulWidget {
 
   bool userPicturePreview;
 
-  MetadataWidget({super.key, 
+  UserMetadataWidget({super.key,
     required this.pubkey,
-    this.metadata,
+    this.user,
     this.jumpable = false,
     this.showBadges = false,
     this.userPicturePreview = false,
@@ -32,15 +32,15 @@ class MetadataWidget extends StatefulWidget {
   }
 }
 
-class _MetadataWidgetState extends State<MetadataWidget> {
+class _MetadataWidgetState extends State<UserMetadataWidget> {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     List<Widget> mainList = [];
 
-    mainList.add(MetadataTopWidget(
+    mainList.add(UserTopWidget(
       pubkey: widget.pubkey,
-      metadata: widget.metadata,
+      user: widget.user,
       jumpable: widget.jumpable,
       userPicturePreview: widget.userPicturePreview,
     ));
@@ -52,8 +52,8 @@ class _MetadataWidgetState extends State<MetadataWidget> {
       ));
     }
 
-    if (widget.metadata != null &&
-        StringUtil.isNotBlank(widget.metadata!.about)) {
+    if (widget.user != null &&
+        StringUtil.isNotBlank(widget.user!.about)) {
       mainList.add(
         Container(
           width: double.maxFinite,
@@ -67,7 +67,7 @@ class _MetadataWidgetState extends State<MetadataWidget> {
           child: SizedBox(
             width: double.maxFinite,
             child: ContentWidget(
-              content: widget.metadata!.about,
+              content: widget.user!.about,
               // TODO this should add source event
               showLinkPreview: false,
             ),

--- a/lib/component/user/user_pic_widget.dart
+++ b/lib/component/user/user_pic_widget.dart
@@ -5,7 +5,7 @@ import 'package:nostrmo/provider/settings_provider.dart';
 import 'package:nostrmo/util/theme_util.dart';
 import 'package:provider/provider.dart';
 
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../provider/metadata_provider.dart';
 import '../image_widget.dart';
 
@@ -18,13 +18,13 @@ class UserPicWidget extends StatefulWidget {
   final double width;
 
   /// The metadata of the user. This is optional.
-  final Metadata? metadata;
+  final User? user;
 
   const UserPicWidget({
     super.key,
     required this.pubkey,
     required this.width,
-    this.metadata,
+    this.user,
   });
 
   @override
@@ -36,18 +36,18 @@ class UserPicWidget extends StatefulWidget {
 class _UserPicWidgetState extends State<UserPicWidget> {
   @override
   Widget build(BuildContext context) {
-    if (widget.metadata != null) {
-      return buildWidget(widget.metadata);
+    if (widget.user != null) {
+      return buildWidget(widget.user);
     }
 
     // Using Selector to watch changes in MetadataProvider and rebuild widget
     // accordingly.
-    return Selector<MetadataProvider, Metadata?>(
-      builder: (context, metadata, child) {
-        return buildWidget(metadata);
+    return Selector<MetadataProvider, User?>(
+      builder: (context, user, child) {
+        return buildWidget(user);
       },
       selector: (_, provider) {
-        return provider.getMetadata(widget.pubkey);
+        return provider.getUser(widget.pubkey);
       },
     );
   }
@@ -56,7 +56,7 @@ class _UserPicWidgetState extends State<UserPicWidget> {
   ///
   /// If metadata is provided, it will use the picture URL from the metadata
   /// to display the profile picture. Otherwise, it will use a placeholder.
-  Widget buildWidget(Metadata? metadata) {
+  Widget buildWidget(User? user) {
     final themeData = Theme.of(context);
     var provider = Provider.of<SettingsProvider>(context);
 
@@ -64,15 +64,15 @@ class _UserPicWidgetState extends State<UserPicWidget> {
     double imageBorder = widget.width / 14;
 
     Widget? imageWidget;
-    if (metadata != null) {
+    if (user != null) {
       // Checking if profile picture preview is enabled and metadata contains a
       // picture.
       bool showPreview = provider.profilePicturePreview != OpenStatus.CLOSE;
-      bool hasMetadataPic = StringUtil.isNotBlank(metadata.picture);
+      bool hasMetadataPic = StringUtil.isNotBlank(user.picture);
 
       if (showPreview && hasMetadataPic) {
         imageWidget = ImageWidget(
-          imageUrl: metadata.picture!,
+          imageUrl: user.picture!,
           width: widget.width - imageBorder * 2,
           height: widget.width - imageBorder * 2,
           fit: BoxFit.cover,

--- a/lib/component/user/user_pic_widget.dart
+++ b/lib/component/user/user_pic_widget.dart
@@ -6,7 +6,7 @@ import 'package:nostrmo/util/theme_util.dart';
 import 'package:provider/provider.dart';
 
 import '../../data/user.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../image_widget.dart';
 
 /// A stateful widget to display user's profile picture
@@ -40,9 +40,9 @@ class _UserPicWidgetState extends State<UserPicWidget> {
       return buildWidget(widget.user);
     }
 
-    // Using Selector to watch changes in MetadataProvider and rebuild widget
+    // Using Selector to watch changes in UserProvider and rebuild widget
     // accordingly.
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
       builder: (context, user, child) {
         return buildWidget(user);
       },

--- a/lib/component/user/user_top_widget.dart
+++ b/lib/component/user/user_top_widget.dart
@@ -15,14 +15,14 @@ import 'package:nostrmo/util/router_util.dart';
 import 'package:nostrmo/util/table_mode_util.dart';
 
 import '../../consts/base.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../confirm_dialog.dart';
 import '../image_widget.dart';
 import '../image_preview_dialog.dart';
 import '../zap/zap_bottom_sheet_widget.dart';
 import 'follow_btn_widget.dart';
 
-class MetadataTopWidget extends StatefulWidget {
+class UserTopWidget extends StatefulWidget {
   static double getPcBannerHeight(double maxHeight) {
     var height = maxHeight * 0.2;
     if (height > 200) {
@@ -34,7 +34,7 @@ class MetadataTopWidget extends StatefulWidget {
 
   String pubkey;
 
-  Metadata? metadata;
+  User? user;
 
   // is local user
   bool isLocal;
@@ -43,10 +43,10 @@ class MetadataTopWidget extends StatefulWidget {
 
   bool userPicturePreview;
 
-  MetadataTopWidget({
+  UserTopWidget({
     super.key,
     required this.pubkey,
-    this.metadata,
+    this.user,
     this.isLocal = false,
     this.jumpable = false,
     this.userPicturePreview = false,
@@ -54,11 +54,11 @@ class MetadataTopWidget extends StatefulWidget {
 
   @override
   State<StatefulWidget> createState() {
-    return _MetadataTopWidgetState();
+    return _UserTopWidgetState();
   }
 }
 
-class _MetadataTopWidgetState extends State<MetadataTopWidget> {
+class _UserTopWidgetState extends State<UserTopWidget> {
   static const double IMAGE_BORDER = 4;
 
   static const double IMAGE_WIDTH = 80;
@@ -86,28 +86,28 @@ class _MetadataTopWidgetState extends State<MetadataTopWidget> {
     var bannerHeight = maxWidth / 3;
     if (TableModeUtil.isTableMode()) {
       bannerHeight =
-          MetadataTopWidget.getPcBannerHeight(mediaDataCache.size.height);
+          UserTopWidget.getPcBannerHeight(mediaDataCache.size.height);
     }
 
     String nip19Name = Nip19.encodeSimplePubKey(widget.pubkey);
     String displayName = "";
     String? name;
-    if (widget.metadata != null) {
-      if (StringUtil.isNotBlank(widget.metadata!.displayName)) {
-        displayName = widget.metadata!.displayName!;
-        if (StringUtil.isNotBlank(widget.metadata!.name)) {
-          name = widget.metadata!.name;
+    if (widget.user != null) {
+      if (StringUtil.isNotBlank(widget.user!.displayName)) {
+        displayName = widget.user!.displayName!;
+        if (StringUtil.isNotBlank(widget.user!.name)) {
+          name = widget.user!.name;
         }
-      } else if (StringUtil.isNotBlank(widget.metadata!.name)) {
-        displayName = widget.metadata!.name!;
+      } else if (StringUtil.isNotBlank(widget.user!.name)) {
+        displayName = widget.user!.name!;
       }
     }
 
     Widget? bannerImage;
-    if (widget.metadata != null &&
-        StringUtil.isNotBlank(widget.metadata!.banner)) {
+    if (widget.user != null &&
+        StringUtil.isNotBlank(widget.user!.banner)) {
       bannerImage = ImageWidget(
-        imageUrl: widget.metadata!.banner!,
+        imageUrl: widget.user!.banner!,
         width: maxWidth,
         height: bannerHeight,
         fit: BoxFit.cover,
@@ -136,9 +136,9 @@ class _MetadataTopWidgetState extends State<MetadataTopWidget> {
     )));
 
     if (!widget.isLocal) {
-      if (widget.metadata != null &&
-          (StringUtil.isNotBlank(widget.metadata!.lud06) ||
-              StringUtil.isNotBlank(widget.metadata!.lud16))) {
+      if (widget.user != null &&
+          (StringUtil.isNotBlank(widget.user!.lud06) ||
+              StringUtil.isNotBlank(widget.user!.lud16))) {
         topBtnList.add(wrapBtn(MetadataIconBtn(
           onTap: openZapDialog,
           iconData: Icons.currency_bitcoin,
@@ -212,37 +212,37 @@ class _MetadataTopWidgetState extends State<MetadataTopWidget> {
       ),
     ));
     topList.add(userNameWidget);
-    if (widget.metadata != null) {
+    if (widget.user != null) {
       topList.add(MetadataIconDataComp(
         iconData: Icons.key,
         text: nip19PubKey,
         textBG: true,
         onTap: copyPubKey,
       ));
-      if (StringUtil.isNotBlank(widget.metadata!.nip05)) {
+      if (StringUtil.isNotBlank(widget.user!.nip05)) {
         topList.add(MetadataIconDataComp(
-          text: widget.metadata!.nip05!,
+          text: widget.user!.nip05!,
           leftWidget: Container(
             margin: const EdgeInsets.only(right: 2),
             child: Nip05ValidWidget(pubkey: widget.pubkey),
           ),
         ));
       }
-      if (widget.metadata != null) {
-        if (StringUtil.isNotBlank(widget.metadata!.website)) {
+      if (widget.user != null) {
+        if (StringUtil.isNotBlank(widget.user!.website)) {
           topList.add(MetadataIconDataComp(
             iconData: Icons.link,
-            text: widget.metadata!.website!,
+            text: widget.user!.website!,
             onTap: () {
-              WebViewWidget.open(context, widget.metadata!.website!);
+              WebViewWidget.open(context, widget.user!.website!);
             },
           ));
         }
-        if (StringUtil.isNotBlank(widget.metadata!.lud16)) {
+        if (StringUtil.isNotBlank(widget.user!.lud16)) {
           topList.add(MetadataIconDataComp(
             iconData: Icons.bolt,
             iconColor: Colors.orange,
-            text: widget.metadata!.lud16!,
+            text: widget.user!.lud16!,
           ));
         }
       }
@@ -251,7 +251,7 @@ class _MetadataTopWidgetState extends State<MetadataTopWidget> {
     Widget userImageWidget = UserPicWidget(
       pubkey: widget.pubkey,
       width: IMAGE_WIDTH,
-      metadata: widget.metadata,
+      user: widget.user,
     );
     if (widget.userPicturePreview) {
       userImageWidget = GestureDetector(
@@ -353,10 +353,10 @@ class _MetadataTopWidgetState extends State<MetadataTopWidget> {
   }
 
   void userPicturePreview() {
-    if (widget.metadata != null &&
-        StringUtil.isNotBlank(widget.metadata!.picture)) {
+    if (widget.user != null &&
+        StringUtil.isNotBlank(widget.user!.picture)) {
       List<ImageProvider> imageProviders = [];
-      imageProviders.add(CachedNetworkImageProvider(widget.metadata!.picture!));
+      imageProviders.add(CachedNetworkImageProvider(widget.user!.picture!));
 
       MultiImageProvider multiImageProvider =
           MultiImageProvider(imageProviders, initialIndex: 0);

--- a/lib/component/user/user_top_widget.dart
+++ b/lib/component/user/user_top_widget.dart
@@ -370,7 +370,7 @@ class _UserTopWidgetState extends State<UserTopWidget> {
     List<EventZapInfo> list = [];
     String relayAddr = "";
     var relayListMetadata =
-        metadataProvider.getRelayListMetadata(widget.pubkey);
+        userProvider.getRelayListMetadata(widget.pubkey);
     if (relayListMetadata != null &&
         relayListMetadata.writeAbleRelays.isNotEmpty) {
       relayAddr = relayListMetadata.writeAbleRelays.first;

--- a/lib/component/zap/zap_bottom_sheet_user_widget.dart
+++ b/lib/component/zap/zap_bottom_sheet_user_widget.dart
@@ -3,7 +3,7 @@ import 'package:nostrmo/component/user/simple_name_widget.dart';
 import 'package:provider/provider.dart';
 
 import '../../consts/base.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../provider/metadata_provider.dart';
 import '../user/user_pic_widget.dart';
 
@@ -36,8 +36,8 @@ class _ZapBottomSheetUserWidgetState extends State<ZapBottomSheetUserWidget> {
     final themeData = Theme.of(context);
     var scaffoldBackgroundColor = themeData.scaffoldBackgroundColor;
 
-    return Selector<MetadataProvider, Metadata?>(
-      builder: (context, metadata, child) {
+    return Selector<MetadataProvider, User?>(
+      builder: (context, user, child) {
         Widget userNameWidget = Container(
           width: widget.configMaxWidth ? 100 : null,
           margin: const EdgeInsets.only(
@@ -48,7 +48,7 @@ class _ZapBottomSheetUserWidgetState extends State<ZapBottomSheetUserWidget> {
           alignment: Alignment.center,
           child: SimpleNameWidget(
             pubkey: widget.pubkey,
-            metadata: metadata,
+            user: user,
             maxLines: 1,
             textOverflow: TextOverflow.ellipsis,
           ),
@@ -68,7 +68,7 @@ class _ZapBottomSheetUserWidgetState extends State<ZapBottomSheetUserWidget> {
           child: UserPicWidget(
             pubkey: widget.pubkey,
             width: IMAGE_WIDTH,
-            metadata: metadata,
+            user: user,
           ),
         );
 
@@ -84,7 +84,7 @@ class _ZapBottomSheetUserWidgetState extends State<ZapBottomSheetUserWidget> {
         );
       },
       selector: (_, provider) {
-        return provider.getMetadata(widget.pubkey);
+        return provider.getUser(widget.pubkey);
       },
     );
   }

--- a/lib/component/zap/zap_bottom_sheet_user_widget.dart
+++ b/lib/component/zap/zap_bottom_sheet_user_widget.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 
 import '../../consts/base.dart';
 import '../../data/user.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../user/user_pic_widget.dart';
 
 class ZapBottomSheetUserWidget extends StatefulWidget {
@@ -36,7 +36,7 @@ class _ZapBottomSheetUserWidgetState extends State<ZapBottomSheetUserWidget> {
     final themeData = Theme.of(context);
     var scaffoldBackgroundColor = themeData.scaffoldBackgroundColor;
 
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
       builder: (context, user, child) {
         Widget userNameWidget = Container(
           width: widget.configMaxWidth ? 100 : null,

--- a/lib/component/zap/zap_bottom_sheet_widget.dart
+++ b/lib/component/zap/zap_bottom_sheet_widget.dart
@@ -19,7 +19,7 @@ class ZapBottomSheetWidget extends StatefulWidget {
     if (zapInfos.isEmpty) {
       String relayAddr = "";
       var relayListMetadata =
-          metadataProvider.getRelayListMetadata(event.pubkey);
+          userProvider.getRelayListMetadata(event.pubkey);
       if (relayListMetadata != null &&
           relayListMetadata.writeAbleRelays.isNotEmpty) {
         relayAddr = relayListMetadata.writeAbleRelays.first;

--- a/lib/component/zap/zaps_send_dialog.dart
+++ b/lib/component/zap/zaps_send_dialog.dart
@@ -3,7 +3,7 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/component/cust_state.dart';
 import 'package:nostrmo/component/user/name_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/provider/metadata_provider.dart';
 import 'package:provider/provider.dart';
 
@@ -13,7 +13,7 @@ import '../../util/lightning_util.dart';
 import '../../util/router_util.dart';
 import '../../util/theme_util.dart';
 import '../../util/zap_action.dart';
-import '../user/metadata_top_widget.dart';
+import '../user/user_top_widget.dart';
 
 class ZapsSendDialog extends StatefulWidget {
   Map<String, int> pubkeyZapNumbers;
@@ -159,8 +159,8 @@ class ZapsSendDialogItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final localization = S.of(context);
-    return Selector<MetadataProvider, Metadata?>(
-        builder: (context, metadata, child) {
+    return Selector<MetadataProvider, User?>(
+        builder: (context, user, child) {
       var userPicComp = UserPicWidget(pubkey: pubkey, width: height);
 
       var nameColum = Container(
@@ -173,7 +173,7 @@ class ZapsSendDialogItem extends StatelessWidget {
           children: [
             NameWidget(
               pubkey: pubkey,
-              metadata: metadata,
+              user: user,
             ),
             Text(
               "$zapNumber Sats",
@@ -232,7 +232,7 @@ class ZapsSendDialogItem extends StatelessWidget {
         ],
       );
     }, selector: (context, provider) {
-      return provider.getMetadata(pubkey);
+      return provider.getUser(pubkey);
     });
   }
 }

--- a/lib/component/zap/zaps_send_dialog.dart
+++ b/lib/component/zap/zaps_send_dialog.dart
@@ -4,7 +4,7 @@ import 'package:nostrmo/component/cust_state.dart';
 import 'package:nostrmo/component/user/name_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/data/user.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import 'package:provider/provider.dart';
 
 import '../../consts/base.dart';
@@ -159,7 +159,7 @@ class ZapsSendDialogItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final localization = S.of(context);
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
         builder: (context, user, child) {
       var userPicComp = UserPicWidget(pubkey: pubkey, width: height);
 

--- a/lib/data/user.dart
+++ b/lib/data/user.dart
@@ -1,4 +1,4 @@
-class Metadata {
+class User {
   String? pubkey;
   String? name;
   String? displayName;
@@ -12,7 +12,7 @@ class Metadata {
   int? updated_at;
   int? valid;
 
-  Metadata({
+  User({
     this.pubkey,
     this.name,
     this.displayName,
@@ -27,23 +27,23 @@ class Metadata {
     this.valid,
   });
 
-  Metadata.fromJson(Map<String, dynamic> json) {
-    pubkey = json['pub_key'];
-    name = json['name'];
-    displayName = json['display_name'];
-    picture = json['picture'];
-    banner = json['banner'];
-    website = json['website'];
-    about = json['about'];
-    if (json['nip05'] != null && json['nip05'] is String) {
-      nip05 = json['nip05'];
-    }
-    lud16 = json['lud16'];
-    lud06 = json['lud06'];
-    if (json['updated_at'] != null && json['updated_at'] is int) {
-      updated_at = json['updated_at'];
-    }
-    valid = json['valid'];
+  factory User.fromJson(Map<String, dynamic> json) {
+    final nip05 = json['nip05'];
+    final updated_at = json['updated_at'];
+    return User(
+      pubkey: json['pub_key'],
+      name: json['name'],
+      displayName: json['display_name'],
+      picture: json['picture'],
+      banner: json['banner'],
+      website: json['website'],
+      about: json['about'],
+      nip05: nip05 != null && nip05 is String ? nip05 : null,
+      lud16: json['lud16'],
+      lud06: json['lud06'],
+      updated_at: updated_at != null && updated_at is int ? updated_at : null,
+      valid: json['valid'],
+    );
   }
 
   Map<String, dynamic> toFullJson() {

--- a/lib/data/user.dart
+++ b/lib/data/user.dart
@@ -9,7 +9,7 @@ class User {
   String? nip05;
   String? lud16;
   String? lud06;
-  int? updated_at;
+  int? updatedAt;
   int? valid;
 
   User({
@@ -23,13 +23,13 @@ class User {
     this.nip05,
     this.lud16,
     this.lud06,
-    this.updated_at,
+    this.updatedAt,
     this.valid,
   });
 
   factory User.fromJson(Map<String, dynamic> json) {
     final nip05 = json['nip05'];
-    final updated_at = json['updated_at'];
+    final updatedAt = json['updated_at'];
     return User(
       pubkey: json['pub_key'],
       name: json['name'],
@@ -41,7 +41,7 @@ class User {
       nip05: nip05 != null && nip05 is String ? nip05 : null,
       lud16: json['lud16'],
       lud06: json['lud06'],
-      updated_at: updated_at != null && updated_at is int ? updated_at : null,
+      updatedAt: updatedAt != null && updatedAt is int ? updatedAt : null,
       valid: json['valid'],
     );
   }
@@ -63,7 +63,7 @@ class User {
     data['nip05'] = nip05;
     data['lud16'] = lud16;
     data['lud06'] = lud06;
-    data['updated_at'] = updated_at;
+    data['updated_at'] = updatedAt;
     data['valid'] = valid;
     return data;
   }

--- a/lib/data/user_db.dart
+++ b/lib/data/user_db.dart
@@ -1,37 +1,37 @@
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:sqflite/sqflite.dart';
 
 import 'db.dart';
 
-class MetadataDB {
-  static Future<List<Metadata>> all({DatabaseExecutor? db}) async {
-    List<Metadata> objs = [];
+class UserDB {
+  static Future<List<User>> all({DatabaseExecutor? db}) async {
+    List<User> objs = [];
     Database db = await DB.getCurrentDatabase();
     List<Map<String, dynamic>> list =
         await db.rawQuery("select * from metadata");
     for (var i = 0; i < list.length; i++) {
       var json = list[i];
-      objs.add(Metadata.fromJson(json));
+      objs.add(User.fromJson(json));
     }
     return objs;
   }
 
-  static Future<Metadata?> get(String pubkey, {DatabaseExecutor? db}) async {
+  static Future<User?> get(String pubkey, {DatabaseExecutor? db}) async {
     db = await DB.getDB(db);
     var list =
         await db.query("metadata", where: "pub_key = ?", whereArgs: [pubkey]);
     if (list.isNotEmpty) {
-      return Metadata.fromJson(list[0]);
+      return User.fromJson(list[0]);
     }
     return null;
   }
 
-  static Future<int> insert(Metadata o, {DatabaseExecutor? db}) async {
+  static Future<int> insert(User o, {DatabaseExecutor? db}) async {
     db = await DB.getDB(db);
     return await db.insert("metadata", o.toFullJson());
   }
 
-  static Future update(Metadata o, {DatabaseExecutor? db}) async {
+  static Future update(User o, {DatabaseExecutor? db}) async {
     db = await DB.getDB(db);
     await db.update("metadata", o.toJson(),
         where: "pub_key = ?", whereArgs: [o.pubkey]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,7 +76,7 @@ import 'provider/link_preview_data_provider.dart';
 import 'provider/list_provider.dart';
 import 'provider/list_set_provider.dart';
 import 'provider/mention_me_provider.dart';
-import 'provider/metadata_provider.dart';
+import 'provider/user_provider.dart';
 import 'provider/music_info_cache.dart';
 import 'provider/pc_router_fake_provider.dart';
 import 'provider/relay_provider.dart';
@@ -118,7 +118,7 @@ late SharedPreferences sharedPreferences;
 
 late SettingsProvider settingsProvider;
 
-late MetadataProvider metadataProvider;
+late UserProvider userProvider;
 
 late ContactListProvider contactListProvider;
 
@@ -211,10 +211,10 @@ Future<void> initializeProviders({bool isTesting = false}) async {
   sharedPreferences = dataFutureResultList[1] as SharedPreferences;
 
   var settingTask = SettingsProvider.getInstance();
-  var metadataTask = MetadataProvider.getInstance();
-  var futureResultList = await Future.wait([settingTask, metadataTask]);
+  var userTask = UserProvider.getInstance();
+  var futureResultList = await Future.wait([settingTask, userTask]);
   settingsProvider = futureResultList[0] as SettingsProvider;
-  metadataProvider = futureResultList[1] as MetadataProvider;
+  userProvider = futureResultList[1] as UserProvider;
   contactListProvider = ContactListProvider.getInstance();
   followEventProvider = FollowEventProvider();
   followNewEventProvider = FollowNewEventProvider();
@@ -472,8 +472,8 @@ class _MyApp extends State<MyApp> {
         ListenableProvider<SettingsProvider>.value(
           value: settingsProvider,
         ),
-        ListenableProvider<MetadataProvider>.value(
-          value: metadataProvider,
+        ListenableProvider<UserProvider>.value(
+          value: userProvider,
         ),
         ListenableProvider<IndexProvider>.value(
           value: indexProvider,

--- a/lib/provider/metadata_provider.dart
+++ b/lib/provider/metadata_provider.dart
@@ -165,7 +165,7 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
         var jsonObj = jsonDecode(event.content);
         var user = User.fromJson(jsonObj);
         user.pubkey = event.pubkey;
-        user.updated_at = event.createdAt;
+        user.updatedAt = event.createdAt;
 
         // check cache
         final oldUser = _userCache[user.pubkey];
@@ -175,7 +175,7 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
           // cache
           _userCache[user.pubkey!] = user;
           // refresh
-        } else if (oldUser.updated_at! < user.updated_at!) {
+        } else if (oldUser.updatedAt! < user.updatedAt!) {
           // db
           UserDB.update(user);
           // cache

--- a/lib/provider/user_provider.dart
+++ b/lib/provider/user_provider.dart
@@ -10,7 +10,7 @@ import '../data/user.dart';
 import '../data/user_db.dart';
 import '../main.dart';
 
-class MetadataProvider extends ChangeNotifier with LaterFunction {
+class UserProvider extends ChangeNotifier with LaterFunction {
   final Map<String, RelayListMetadata> _relayListMetadataCache = {};
 
   final Map<String, User> _userCache = {};
@@ -19,39 +19,39 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
 
   final Map<String, ContactList> _contactListMap = {};
 
-  static MetadataProvider? _metadataProvider;
+  static UserProvider? _userProvider;
 
-  static Future<MetadataProvider> getInstance() async {
-    if (_metadataProvider == null) {
-      _metadataProvider = MetadataProvider();
+  static Future<UserProvider> getInstance() async {
+    if (_userProvider == null) {
+      _userProvider = UserProvider();
 
       var list = await UserDB.all();
       for (var md in list) {
         if (md.valid == Nip05Status.NIP05_NOT_VALID) {
           md.valid = null;
         }
-        _metadataProvider!._userCache[md.pubkey!] = md;
+        _userProvider!._userCache[md.pubkey!] = md;
       }
 
       var events = await EventDB.list(Base.defaultDataIndex,
           [EventKind.RELAY_LIST_METADATA, EventKind.CONTACT_LIST], 0, 1000000);
-      _metadataProvider!._contactListMap.clear();
+      _userProvider!._contactListMap.clear();
       for (var e in events) {
         if (e.kind == EventKind.RELAY_LIST_METADATA) {
           var relayListMetadata = RelayListMetadata.fromEvent(e);
-          _metadataProvider!._relayListMetadataCache[relayListMetadata.pubkey] =
+          _userProvider!._relayListMetadataCache[relayListMetadata.pubkey] =
               relayListMetadata;
         } else if (e.kind == EventKind.CONTACT_LIST) {
           var contactList = ContactList.fromJson(e.tags, e.createdAt);
-          _metadataProvider!._contactListMap[e.pubkey] = contactList;
+          _userProvider!._contactListMap[e.pubkey] = contactList;
         }
       }
 
       // lazyTimeMS begin bigger and request less
-      _metadataProvider!.laterTimeMS = 2000;
+      _userProvider!.laterTimeMS = 2000;
     }
 
-    return _metadataProvider!;
+    return _userProvider!;
   }
 
   List<User> findUser(String str, {int? limit = 5}) {
@@ -310,7 +310,7 @@ class MetadataProvider extends ChangeNotifier with LaterFunction {
 
   List<String> getExtralRelays(String pubkey, bool isWrite) {
     List<String> tempRelays = [];
-    var relayListMetadata = metadataProvider.getRelayListMetadata(pubkey);
+    var relayListMetadata = userProvider.getRelayListMetadata(pubkey);
     if (relayListMetadata != null) {
       late List<String> relays;
       if (isWrite) {

--- a/lib/provider/wot_provider.dart
+++ b/lib/provider/wot_provider.dart
@@ -112,7 +112,7 @@ class WotProvider extends ChangeNotifier {
       _pubkeys[pubkey] = 1;
 
       // The pubkeys your friend had followed. (Trust !)
-      var contactList = metadataProvider.getContactList(pubkey);
+      var contactList = userProvider.getContactList(pubkey);
       if (contactList != null) {
         var contacts = contactList.list();
         for (var contact in contacts) {
@@ -120,7 +120,7 @@ class WotProvider extends ChangeNotifier {
 
           // your friend's friend's contactList. (Half Trust, don't pull if not exist!)
           var ffContactList =
-              metadataProvider.getContactList(contact.publicKey);
+              userProvider.getContactList(contact.publicKey);
           if (ffContactList != null) {
             var ffContacts = ffContactList.list();
             for (var ffcontact in ffContacts) {
@@ -137,7 +137,7 @@ class WotProvider extends ChangeNotifier {
       if (nostr != null) {
         var tempPubkeys = notFoundContactListPubkeys.keys;
         for (var pubkey in tempPubkeys) {
-          metadataProvider.update(pubkey);
+          userProvider.update(pubkey);
         }
       }
     }

--- a/lib/router/dm/dm_detail_widget.dart
+++ b/lib/router/dm/dm_detail_widget.dart
@@ -17,7 +17,7 @@ import '../../component/editor/tag_embed_builder.dart';
 import '../../component/editor/video_embed_builder.dart';
 import '../../component/user/name_widget.dart';
 import '../../consts/base.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
 import '../../provider/dm_provider.dart';
@@ -64,15 +64,15 @@ class _DMDetailWidgetState extends CustState<DMDetailWidget> with EditorMixin {
       detail = newDetail;
     }
 
-    var nameComponnet = Selector<MetadataProvider, Metadata?>(
-      builder: (context, metadata, child) {
+    var nameComponnet = Selector<MetadataProvider, User?>(
+      builder: (context, user, child) {
         return NameWidget(
           pubkey: detail!.dmSession.pubkey,
-          metadata: metadata,
+          user: user,
         );
       },
       selector: (_, provider) {
-        return provider.getMetadata(detail!.dmSession.pubkey);
+        return provider.getUser(detail!.dmSession.pubkey);
       },
     );
 

--- a/lib/router/dm/dm_detail_widget.dart
+++ b/lib/router/dm/dm_detail_widget.dart
@@ -21,7 +21,7 @@ import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
 import '../../provider/dm_provider.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../../util/router_util.dart';
 import 'dm_detail_item_widget.dart';
 
@@ -64,7 +64,7 @@ class _DMDetailWidgetState extends CustState<DMDetailWidget> with EditorMixin {
       detail = newDetail;
     }
 
-    var nameComponnet = Selector<MetadataProvider, User?>(
+    var nameComponnet = Selector<UserProvider, User?>(
       builder: (context, user, child) {
         return NameWidget(
           pubkey: detail!.dmSession.pubkey,

--- a/lib/router/dm/dm_session_list_item_widget.dart
+++ b/lib/router/dm/dm_session_list_item_widget.dart
@@ -6,7 +6,7 @@ import 'package:nostrmo/component/point_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/consts/base.dart';
 import 'package:nostrmo/consts/router_path.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/provider/dm_provider.dart';
 import 'package:nostrmo/provider/metadata_provider.dart';
 import 'package:nostrmo/util/router_util.dart';
@@ -36,8 +36,8 @@ class _DMSessionListItemWidgetState extends State<DMSessionListItemWidget>
 
   @override
   Widget build(BuildContext context) {
-    var main = Selector<MetadataProvider, Metadata?>(
-      builder: (context, metadata, child) {
+    var main = Selector<MetadataProvider, User?>(
+      builder: (context, user, child) {
         final themeData = Theme.of(context);
         var mainColor = themeData.primaryColor;
         var hintColor = themeData.hintColor;
@@ -114,7 +114,7 @@ class _DMSessionListItemWidgetState extends State<DMSessionListItemWidget>
                           Expanded(
                             child: NameWidget(
                               pubkey: dmSession.pubkey,
-                              metadata: metadata,
+                              user: user,
                               maxLines: 1,
                               textOverflow: TextOverflow.ellipsis,
                             ),
@@ -146,7 +146,7 @@ class _DMSessionListItemWidgetState extends State<DMSessionListItemWidget>
         );
       },
       selector: (_, provider) {
-        return provider.getMetadata(widget.detail.dmSession.pubkey);
+        return provider.getUser(widget.detail.dmSession.pubkey);
       },
     );
 

--- a/lib/router/dm/dm_session_list_item_widget.dart
+++ b/lib/router/dm/dm_session_list_item_widget.dart
@@ -8,7 +8,7 @@ import 'package:nostrmo/consts/base.dart';
 import 'package:nostrmo/consts/router_path.dart';
 import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/provider/dm_provider.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import 'package:nostrmo/util/router_util.dart';
 import 'package:provider/provider.dart';
 
@@ -36,7 +36,7 @@ class _DMSessionListItemWidgetState extends State<DMSessionListItemWidget>
 
   @override
   Widget build(BuildContext context) {
-    var main = Selector<MetadataProvider, User?>(
+    var main = Selector<UserProvider, User?>(
       builder: (context, user, child) {
         final themeData = Theme.of(context);
         var mainColor = themeData.primaryColor;

--- a/lib/router/edit/editor_notify_item_widget.dart
+++ b/lib/router/edit/editor_notify_item_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/provider/metadata_provider.dart';
 import 'package:provider/provider.dart';
 
@@ -33,16 +33,16 @@ class _EditorNotifyItemWidgetState extends State<EditorNotifyItemWidget> {
     var textColor = themeData.appBarTheme.titleTextStyle!.color;
 
     List<Widget> list = [];
-    list.add(Selector<MetadataProvider, Metadata?>(
-        builder: (context, metadata, child) {
+    list.add(Selector<MetadataProvider, User?>(
+        builder: (context, user, child) {
       String name =
-          SimpleNameWidget.getSimpleName(widget.item.pubkey, metadata);
+          SimpleNameWidget.getSimpleName(widget.item.pubkey, user);
       return Text(
         name,
         style: TextStyle(color: textColor),
       );
     }, selector: (_, provider) {
-      return provider.getMetadata(widget.item.pubkey);
+      return provider.getUser(widget.item.pubkey);
     }));
 
     list.add(SizedBox(

--- a/lib/router/edit/editor_notify_item_widget.dart
+++ b/lib/router/edit/editor_notify_item_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:nostrmo/data/user.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import 'package:provider/provider.dart';
 
 import '../../component/user/simple_name_widget.dart';
@@ -33,7 +33,7 @@ class _EditorNotifyItemWidgetState extends State<EditorNotifyItemWidget> {
     var textColor = themeData.appBarTheme.titleTextStyle!.color;
 
     List<Widget> list = [];
-    list.add(Selector<MetadataProvider, User?>(
+    list.add(Selector<UserProvider, User?>(
         builder: (context, user, child) {
       String name =
           SimpleNameWidget.getSimpleName(widget.item.pubkey, user);

--- a/lib/router/follow_set/follow_set_detail_widget.dart
+++ b/lib/router/follow_set/follow_set_detail_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:nostrmo/component/user/simple_metadata_widget.dart';
+import 'package:nostrmo/component/user/simple_user_widget.dart';
 import 'package:nostrmo/consts/base.dart';
 import 'package:nostrmo/generated/l10n.dart';
 import 'package:nostrmo/main.dart';
@@ -138,7 +138,7 @@ class _FollowSetDetailWidgetState extends State<FollowSetDetailWidget> {
                       RouterUtil.router(
                           context, RouterPath.USER, contact.publicKey);
                     },
-                    child: SimpleMetadataWidget(
+                    child: SimpleUserWidget(
                       pubkey: contact.publicKey,
                     ),
                   ),

--- a/lib/router/follow_suggest/follow_suggest_widget.dart
+++ b/lib/router/follow_suggest/follow_suggest_widget.dart
@@ -5,7 +5,7 @@ import 'package:dynamic_height_grid_view/dynamic_height_grid_view.dart';
 import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/component/cust_state.dart';
-import 'package:nostrmo/component/user/simple_metadata_widget.dart';
+import 'package:nostrmo/component/user/simple_user_widget.dart';
 
 import '../../consts/base.dart';
 import '../../generated/l10n.dart';
@@ -54,7 +54,7 @@ class _FollowSuggestWidgetState extends CustState<FollowSuggestWidget> {
 
     List<Widget> userWidgetList = [];
     for (var pubkey in pubkeys) {
-      userWidgetList.add(SimpleMetadataWidget(
+      userWidgetList.add(SimpleUserWidget(
         pubkey: pubkey,
       ));
     }
@@ -67,7 +67,7 @@ class _FollowSuggestWidgetState extends CustState<FollowSuggestWidget> {
         itemCount: pubkeys.length,
         builder: (context, index) {
           var pubkey = pubkeys[index];
-          return SimpleMetadataWidget(
+          return SimpleUserWidget(
             pubkey: pubkey,
             showFollow: true,
           );

--- a/lib/router/follow_suggest/follow_suggest_widget.dart
+++ b/lib/router/follow_suggest/follow_suggest_widget.dart
@@ -174,7 +174,7 @@ class _FollowSuggestWidgetState extends CustState<FollowSuggestWidget> {
   }
 
   void onEvent(Event e) {
-    metadataProvider.onEvent(e);
+    userProvider.onEvent(e);
   }
 
   int getRandomInt(int min, int max) {

--- a/lib/router/globals/users/globals_users_widget.dart
+++ b/lib/router/globals/users/globals_users_widget.dart
@@ -7,10 +7,10 @@ import 'package:provider/provider.dart';
 
 import '../../../component/keep_alive_cust_state.dart';
 import '../../../component/placeholder/metadata_list_placeholder.dart';
-import '../../../component/user/metadata_widget.dart';
+import '../../../component/user/user_metadata_widget.dart';
 import '../../../consts/base.dart';
 import '../../../consts/router_path.dart';
-import '../../../data/metadata.dart';
+import '../../../data/user.dart';
 import '../../../main.dart';
 import '../../../provider/metadata_provider.dart';
 import '../../../util/dio_util.dart';
@@ -51,22 +51,22 @@ class _GlobalsUsersWidgetState extends KeepAliveCustState<GlobalsUsersWidget> {
         return Container(
           color: themeData.cardColor,
           padding: const EdgeInsets.only(bottom: Base.basePadding),
-          child: Selector<MetadataProvider, Metadata?>(
-            builder: (context, metadata, child) {
+          child: Selector<MetadataProvider, User?>(
+            builder: (context, user, child) {
               return GestureDetector(
                 onTap: () {
                   RouterUtil.router(context, RouterPath.USER, pubkey);
                 },
                 behavior: HitTestBehavior.translucent,
-                child: MetadataWidget(
+                child: UserMetadataWidget(
                   pubkey: pubkey,
-                  metadata: metadata,
+                  user: user,
                   jumpable: true,
                 ),
               );
             },
             selector: (_, provider) {
-              return provider.getMetadata(pubkey);
+              return provider.getUser(pubkey);
             },
           ),
         );

--- a/lib/router/globals/users/globals_users_widget.dart
+++ b/lib/router/globals/users/globals_users_widget.dart
@@ -12,7 +12,7 @@ import '../../../consts/base.dart';
 import '../../../consts/router_path.dart';
 import '../../../data/user.dart';
 import '../../../main.dart';
-import '../../../provider/metadata_provider.dart';
+import '../../../provider/user_provider.dart';
 import '../../../util/dio_util.dart';
 import '../../../util/router_util.dart';
 import '../../../util/table_mode_util.dart';
@@ -51,7 +51,7 @@ class _GlobalsUsersWidgetState extends KeepAliveCustState<GlobalsUsersWidget> {
         return Container(
           color: themeData.cardColor,
           padding: const EdgeInsets.only(bottom: Base.basePadding),
-          child: Selector<MetadataProvider, User?>(
+          child: Selector<UserProvider, User?>(
             builder: (context, user, child) {
               return GestureDetector(
                 onTap: () {

--- a/lib/router/group/group_members/group_member_info_widget.dart
+++ b/lib/router/group/group_members/group_member_info_widget.dart
@@ -1,19 +1,20 @@
 import 'package:flutter/material.dart';
-import 'package:nostrmo/data/metadata.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import '../../../component/group/admin_tag_widget.dart';
 import 'package:nostrmo/util/theme_util.dart';
+
+import '../../../component/group/admin_tag_widget.dart';
+import '../../../data/user.dart';
 
 /// Displays some info about a group member.
 class GroupMemberInfoWidget extends StatelessWidget {
   final String pubkey;
-  final Metadata? metadata;
+  final User? user;
   final bool isAdmin;
 
   const GroupMemberInfoWidget({
     super.key,
     required this.pubkey,
-    required this.metadata,
+    required this.user,
     required this.isAdmin,
   });
 
@@ -28,8 +29,8 @@ class GroupMemberInfoWidget extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                metadata?.displayName ??
-                    metadata?.name ??
+                user?.displayName ??
+                    user?.name ??
                     Nip19.encodeSimplePubKey(pubkey),
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
@@ -38,7 +39,7 @@ class GroupMemberInfoWidget extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
               Text(
-                metadata?.nip05 ?? "",
+                user?.nip05 ?? "",
                 style: TextStyle(
                   fontSize: themeData.textTheme.bodySmall!.fontSize,
                   color: themeData.customColors.dimmedColor,

--- a/lib/router/group/group_members/group_member_item_widget.dart
+++ b/lib/router/group/group_members/group_member_item_widget.dart
@@ -1,18 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:nostrmo/data/metadata.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/consts/router_path.dart';
 import 'package:nostrmo/util/router_util.dart';
 import 'package:nostrmo/consts/base.dart';
 import 'package:nostrmo/util/theme_util.dart';
+
+import '../../../data/user.dart';
 import 'group_member_info_widget.dart';
 
 /// Displays a member of a group in a list.
 class GroupMemberItemWidget extends StatelessWidget {
   final GroupIdentifier groupIdentifier;
   final String pubkey;
-  final Metadata? metadata;
+  final User? user;
   final bool isAdmin;
   final double userPicWidth = 30;
 
@@ -20,7 +21,7 @@ class GroupMemberItemWidget extends StatelessWidget {
     super.key,
     required this.groupIdentifier,
     required this.pubkey,
-    required this.metadata,
+    required this.user,
     this.isAdmin = false,
   });
 
@@ -52,7 +53,7 @@ class GroupMemberItemWidget extends StatelessWidget {
                 Expanded(
                   child: GroupMemberInfoWidget(
                     pubkey: pubkey,
-                    metadata: metadata,
+                    user: user,
                     isAdmin: isAdmin,
                   ),
                 ),

--- a/lib/router/group/group_members/group_members_screen.dart
+++ b/lib/router/group/group_members/group_members_screen.dart
@@ -46,9 +46,9 @@ class _GroupMembersWidgetState extends State<GroupMembersWidget> {
     if (groupMembers != null && groupMembers.members != null) {
       // Create a list of member data to sort
       var membersList = groupMembers.members!.map((pubkey) {
-        final metadata = metadataProvider.getMetadata(pubkey);
+        final user = metadataProvider.getUser(pubkey);
         final isAdmin = groupAdmins?.containsUser(pubkey) ?? false;
-        return (pubkey: pubkey, metadata: metadata, isAdmin: isAdmin);
+        return (pubkey: pubkey, user: user, isAdmin: isAdmin);
       }).toList();
 
       // Sort the list - admins first, then by display name
@@ -59,11 +59,11 @@ class _GroupMembersWidgetState extends State<GroupMembersWidget> {
         }
 
         // Then compare by display name
-        final member1Name = member1.metadata?.displayName ??
-            member1.metadata?.name ??
+        final member1Name = member1.user?.displayName ??
+            member1.user?.name ??
             Nip19.encodeSimplePubKey(member1.pubkey);
-        final member2Name = member2.metadata?.displayName ??
-            member2.metadata?.name ??
+        final member2Name = member2.user?.displayName ??
+            member2.user?.name ??
             Nip19.encodeSimplePubKey(member2.pubkey);
         return member1Name.compareTo(member2Name);
       });
@@ -72,7 +72,7 @@ class _GroupMembersWidgetState extends State<GroupMembersWidget> {
             groupIdentifier: groupIdentifier!,
             pubkey: member.pubkey,
             isAdmin: member.isAdmin,
-            metadata: member.metadata,
+            user: member.user,
           )));
     }
 

--- a/lib/router/group/group_members/group_members_screen.dart
+++ b/lib/router/group/group_members/group_members_screen.dart
@@ -3,7 +3,7 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/provider/group_provider.dart';
 import 'package:nostrmo/util/router_util.dart';
 import 'package:provider/provider.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import '../../../component/appbar_back_btn_widget.dart';
 import '../../../generated/l10n.dart';
 import '../../../component/appbar_bottom_border.dart';
@@ -28,7 +28,7 @@ class _GroupMembersWidgetState extends State<GroupMembersWidget> {
     final themeData = Theme.of(context);
     var bodyLargeFontSize = themeData.textTheme.bodyLarge!.fontSize;
     final localization = S.of(context);
-    final metadataProvider = Provider.of<MetadataProvider>(context);
+    final userProvider = Provider.of<UserProvider>(context);
 
     var arg = RouterUtil.routerArgs(context);
     if (arg == null || arg is! GroupIdentifier) {
@@ -46,7 +46,7 @@ class _GroupMembersWidgetState extends State<GroupMembersWidget> {
     if (groupMembers != null && groupMembers.members != null) {
       // Create a list of member data to sort
       var membersList = groupMembers.members!.map((pubkey) {
-        final user = metadataProvider.getUser(pubkey);
+        final user = userProvider.getUser(pubkey);
         final isAdmin = groupAdmins?.containsUser(pubkey) ?? false;
         return (pubkey: pubkey, user: user, isAdmin: isAdmin);
       }).toList();

--- a/lib/router/index/account_manager_widget.dart
+++ b/lib/router/index/account_manager_widget.dart
@@ -7,7 +7,7 @@ import 'package:nostrmo/component/user/name_widget.dart';
 import 'package:nostrmo/component/point_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/consts/router_path.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/provider/metadata_provider.dart';
 import 'package:nostrmo/provider/settings_provider.dart';
 import 'package:nostrmo/util/router_util.dart';
@@ -291,8 +291,8 @@ class _AccountManagerItemWidgetState extends State<AccountManagerItemWidget> {
     }
     final localization = S.of(context);
 
-    return Selector<MetadataProvider, Metadata?>(
-        builder: (context, metadata, child) {
+    return Selector<MetadataProvider, User?>(
+        builder: (context, user, child) {
       Color currentColor = Colors.green;
       List<Widget> list = [];
 
@@ -315,14 +315,14 @@ class _AccountManagerItemWidgetState extends State<AccountManagerItemWidget> {
       list.add(UserPicWidget(
         pubkey: pubkey,
         width: imageWidth,
-        metadata: metadata,
+        user: user,
       ));
 
       list.add(Container(
         margin: const EdgeInsets.only(left: 5, right: 5),
         child: NameWidget(
           pubkey: pubkey,
-          metadata: metadata,
+          user: user,
         ),
       ));
 
@@ -389,7 +389,7 @@ class _AccountManagerItemWidgetState extends State<AccountManagerItemWidget> {
         ),
       );
     }, selector: (_, provider) {
-      return provider.getMetadata(pubkey);
+      return provider.getUser(pubkey);
     });
   }
 

--- a/lib/router/index/account_manager_widget.dart
+++ b/lib/router/index/account_manager_widget.dart
@@ -8,7 +8,7 @@ import 'package:nostrmo/component/point_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/consts/router_path.dart';
 import 'package:nostrmo/data/user.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import 'package:nostrmo/provider/settings_provider.dart';
 import 'package:nostrmo/util/router_util.dart';
 import 'package:provider/provider.dart';
@@ -291,7 +291,7 @@ class _AccountManagerItemWidgetState extends State<AccountManagerItemWidget> {
     }
     final localization = S.of(context);
 
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
         builder: (context, user, child) {
       Color currentColor = Colors.green;
       List<Widget> list = [];

--- a/lib/router/index/index_drawer_content.dart
+++ b/lib/router/index/index_drawer_content.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:nostrmo/component/user/metadata_top_widget.dart';
+import 'package:nostrmo/component/user/user_top_widget.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/consts/base.dart';
 import 'package:nostrmo/consts/router_path.dart';
@@ -9,7 +9,7 @@ import 'package:nostrmo/util/router_util.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
 import '../../provider/metadata_provider.dart';
@@ -85,17 +85,17 @@ class _IndexDrawerContentState extends State<IndexDrawerContent> {
       ));
     } else {
       list.add(Stack(children: [
-        Selector<MetadataProvider, Metadata?>(
-          builder: (context, metadata, child) {
-            return MetadataTopWidget(
+        Selector<MetadataProvider, User?>(
+          builder: (context, user, child) {
+            return UserTopWidget(
               pubkey: pubkey,
-              metadata: metadata,
+              user: user,
               isLocal: true,
               jumpable: true,
             );
           },
           selector: (_, provider) {
-            return provider.getMetadata(pubkey);
+            return provider.getUser(pubkey);
           },
         ),
         Positioned(
@@ -240,8 +240,8 @@ class _IndexDrawerContentState extends State<IndexDrawerContent> {
 
   /// Navigates to the profile edit screen.
   void _jumpToProfileEdit() {
-    var metadata = metadataProvider.getMetadata(nostr!.publicKey);
-    RouterUtil.router(context, RouterPath.PROFILE_EDITOR, metadata);
+    final user = metadataProvider.getUser(nostr!.publicKey);
+    RouterUtil.router(context, RouterPath.PROFILE_EDITOR, user);
   }
 
   /// Displays the account manager modal bottom sheet.

--- a/lib/router/index/index_drawer_content.dart
+++ b/lib/router/index/index_drawer_content.dart
@@ -12,7 +12,7 @@ import 'package:provider/provider.dart';
 import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../../util/table_mode_util.dart';
 import 'account_manager_widget.dart';
 import '../../util/theme_util.dart';
@@ -85,7 +85,7 @@ class _IndexDrawerContentState extends State<IndexDrawerContent> {
       ));
     } else {
       list.add(Stack(children: [
-        Selector<MetadataProvider, User?>(
+        Selector<UserProvider, User?>(
           builder: (context, user, child) {
             return UserTopWidget(
               pubkey: pubkey,
@@ -240,7 +240,7 @@ class _IndexDrawerContentState extends State<IndexDrawerContent> {
 
   /// Navigates to the profile edit screen.
   void _jumpToProfileEdit() {
-    final user = metadataProvider.getUser(nostr!.publicKey);
+    final user = userProvider.getUser(nostr!.publicKey);
     RouterUtil.router(context, RouterPath.PROFILE_EDITOR, user);
   }
 

--- a/lib/router/profile_editor/profile_editor_widget.dart
+++ b/lib/router/profile_editor/profile_editor_widget.dart
@@ -3,7 +3,7 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/util/router_util.dart';
 
 import '../../component/appbar4stack.dart';
@@ -34,7 +34,7 @@ class _ProfileEditorWidgetState extends CustState<ProfileEditorWidget> {
   TextEditingController lud16Controller = TextEditingController();
   TextEditingController lud06Controller = TextEditingController();
 
-  Metadata? metadata;
+  User? user;
 
   String _getText(String? str) {
     return str ?? "";
@@ -43,22 +43,22 @@ class _ProfileEditorWidgetState extends CustState<ProfileEditorWidget> {
   @override
   Widget doBuild(BuildContext context) {
     final localization = S.of(context);
-    if (metadata == null) {
+    if (user == null) {
       var arg = RouterUtil.routerArgs(context);
-      if (arg != null && arg is Metadata) {
-        metadata = arg;
+      if (arg != null && arg is User) {
+        user = arg;
       }
-      metadata ??= Metadata();
+      user ??= User();
 
-      displayNameController.text = _getText(metadata!.displayName);
-      nameController.text = _getText(metadata!.name);
-      aboutController.text = _getText(metadata!.about);
-      pictureController.text = _getText(metadata!.picture);
-      bannerController.text = _getText(metadata!.banner);
-      websiteController.text = _getText(metadata!.website);
-      nip05Controller.text = _getText(metadata!.nip05);
-      lud16Controller.text = _getText(metadata!.lud16);
-      lud06Controller.text = _getText(metadata!.lud06);
+      displayNameController.text = _getText(user!.displayName);
+      nameController.text = _getText(user!.name);
+      aboutController.text = _getText(user!.about);
+      pictureController.text = _getText(user!.picture);
+      bannerController.text = _getText(user!.banner);
+      websiteController.text = _getText(user!.website);
+      nip05Controller.text = _getText(user!.nip05);
+      lud16Controller.text = _getText(user!.lud16);
+      lud06Controller.text = _getText(user!.lud06);
     }
 
     final themeData = Theme.of(context);

--- a/lib/router/relays/relay_info_widget.dart
+++ b/lib/router/relays/relay_info_widget.dart
@@ -12,7 +12,7 @@ import 'package:nostrmo/component/sync_upload_dialog.dart';
 import 'package:nostrmo/component/user/user_pic_widget.dart';
 import 'package:nostrmo/consts/base.dart';
 import 'package:nostrmo/consts/router_path.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/main.dart';
 import 'package:nostrmo/provider/metadata_provider.dart';
 import 'package:nostrmo/util/store_util.dart';
@@ -93,8 +93,8 @@ class _RelayInfoWidgetState extends CustState<RelayInfoWidget> {
 
     list.add(RelayInfoItemWidget(
       title: localization.Owner,
-      child: Selector<MetadataProvider, Metadata?>(
-        builder: (context, metadata, child) {
+      child: Selector<MetadataProvider, User?>(
+        builder: (context, user, child) {
           List<Widget> list = [];
 
           list.add(Container(
@@ -102,7 +102,7 @@ class _RelayInfoWidgetState extends CustState<RelayInfoWidget> {
             child: UserPicWidget(
               pubkey: relayInfo.pubkey,
               width: IMAGE_WIDTH,
-              metadata: metadata,
+              user: user,
             ),
           ));
 
@@ -116,7 +116,7 @@ class _RelayInfoWidgetState extends CustState<RelayInfoWidget> {
           );
         },
         selector: (_, provider) {
-          return provider.getMetadata(relayInfo.pubkey);
+          return provider.getUser(relayInfo.pubkey);
         },
       ),
     ));

--- a/lib/router/relays/relay_info_widget.dart
+++ b/lib/router/relays/relay_info_widget.dart
@@ -14,7 +14,7 @@ import 'package:nostrmo/consts/base.dart';
 import 'package:nostrmo/consts/router_path.dart';
 import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/main.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import 'package:nostrmo/util/store_util.dart';
 import 'package:provider/provider.dart';
 
@@ -93,7 +93,7 @@ class _RelayInfoWidgetState extends CustState<RelayInfoWidget> {
 
     list.add(RelayInfoItemWidget(
       title: localization.Owner,
-      child: Selector<MetadataProvider, User?>(
+      child: Selector<UserProvider, User?>(
         builder: (context, user, child) {
           List<Widget> list = [];
 

--- a/lib/router/search/search_widget.dart
+++ b/lib/router/search/search_widget.dart
@@ -3,9 +3,9 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:nostrmo/component/user/metadata_top_widget.dart';
+import 'package:nostrmo/component/user/user_top_widget.dart';
 import 'package:nostrmo/data/event_find_util.dart';
-import 'package:nostrmo/data/metadata.dart';
+import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/router/search/search_action_item_widget.dart';
 import 'package:nostrmo/router/search/search_actions.dart';
 import 'package:provider/provider.dart';
@@ -120,19 +120,19 @@ class _SearchWidgetState extends CustState<SearchWidget>
         body = ListView.builder(
           controller: scrollController,
           itemBuilder: (BuildContext context, int index) {
-            var metadata = metadatas[index];
+            var user = users[index];
 
             return GestureDetector(
               onTap: () {
-                RouterUtil.router(context, RouterPath.USER, metadata.pubkey);
+                RouterUtil.router(context, RouterPath.USER, user.pubkey);
               },
-              child: MetadataTopWidget(
-                pubkey: metadata.pubkey!,
-                metadata: metadata,
+              child: UserTopWidget(
+                pubkey: user.pubkey!,
+                user: user,
               ),
             );
           },
-          itemCount: metadatas.length,
+          itemCount: users.length,
         );
       } else if (searchAction == SearchActions.searchEventFromCache) {
         loadable = false;
@@ -368,11 +368,11 @@ class _SearchWidgetState extends CustState<SearchWidget>
     }
   }
 
-  List<Metadata> metadatas = [];
+  List<User> users = [];
 
   searchMetadataFromCache() {
     hideKeyBoard();
-    metadatas.clear();
+    users.clear();
     searchAction = SearchActions.searchMetadataFromCache;
 
     var text = controller.text;
@@ -380,7 +380,7 @@ class _SearchWidgetState extends CustState<SearchWidget>
       var list = metadataProvider.findUser(text, limit: searchMemLimit);
 
       setState(() {
-        metadatas = list;
+        users = list;
       });
     }
   }

--- a/lib/router/search/search_widget.dart
+++ b/lib/router/search/search_widget.dart
@@ -377,7 +377,7 @@ class _SearchWidgetState extends CustState<SearchWidget>
 
     var text = controller.text;
     if (StringUtil.isNotBlank(text)) {
-      var list = metadataProvider.findUser(text, limit: searchMemLimit);
+      var list = userProvider.findUser(text, limit: searchMemLimit);
 
       setState(() {
         users = list;

--- a/lib/router/settings/settings_widget.dart
+++ b/lib/router/settings/settings_widget.dart
@@ -22,7 +22,7 @@ import '../../component/enum_selector_widget.dart';
 import '../../component/translate/translate_model_manager.dart';
 import '../../consts/base_consts.dart';
 import '../../consts/image_services.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
 import '../../provider/settings_provider.dart';
@@ -639,7 +639,7 @@ class _SettingsWidgetState extends State<SettingsWidget> with WhenStopFunction {
         waitingDeleteEventBox.clear();
 
         // use a blank metadata to update it
-        var blankMetadata = Metadata();
+        var blankMetadata = User();
         var updateEvent = Event(nostr!.publicKey, EventKind.METADATA, [],
             jsonEncode(blankMetadata));
         nostr!.sendEvent(updateEvent);

--- a/lib/router/settings/settings_widget.dart
+++ b/lib/router/settings/settings_widget.dart
@@ -689,7 +689,7 @@ class _SettingsWidgetState extends State<SettingsWidget> with WhenStopFunction {
       if (index != null) {
         AccountManagerWidgetState.onLogoutTap(index,
             routerBack: true, context: context);
-        metadataProvider.clear();
+        userProvider.clear();
       } else {
         nostr = null;
       }

--- a/lib/router/thread_trace_router/thread_trace_widget.dart
+++ b/lib/router/thread_trace_router/thread_trace_widget.dart
@@ -238,7 +238,7 @@ class _ThreadTraceWidgetState extends State<ThreadTraceWidget>
     }
     if (StringUtil.isNotBlank(eventRelation.pubkey)) {
       var subEventPubkeyRelays =
-          metadataProvider.getExtralRelays(eventRelation.pubkey, false);
+          userProvider.getExtralRelays(eventRelation.pubkey, false);
       tempRelays.addAll(subEventPubkeyRelays);
     }
 
@@ -295,7 +295,7 @@ class _ThreadTraceWidgetState extends State<ThreadTraceWidget>
     }
     if (StringUtil.isNotBlank(subEventPubkey)) {
       var subEventPubkeyRelays =
-          metadataProvider.getExtralRelays(subEventPubkey!, false);
+          userProvider.getExtralRelays(subEventPubkey!, false);
       tempRelays.addAll(subEventPubkeyRelays);
     }
     nostr!.query([filter.toJson()], onParentEvent,

--- a/lib/router/user/contact_list_widget.dart
+++ b/lib/router/user/contact_list_widget.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:provider/provider.dart';
 
-import '../../component/user/metadata_widget.dart';
+import '../../component/user/user_metadata_widget.dart';
 import '../../consts/base.dart';
 import '../../consts/router_path.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../provider/metadata_provider.dart';
 import '../../util/router_util.dart';
 import '../../util/table_mode_util.dart';
@@ -36,23 +36,23 @@ class _ContactListWidgetState extends State<ContactListWidget> {
         var contact = list![index];
         return Container(
           margin: const EdgeInsets.only(bottom: Base.basePaddingHalf),
-          child: Selector<MetadataProvider, Metadata?>(
-            builder: (context, metadata, child) {
+          child: Selector<MetadataProvider, User?>(
+            builder: (context, user, child) {
               return GestureDetector(
                 onTap: () {
                   RouterUtil.router(
                       context, RouterPath.USER, contact.publicKey);
                 },
                 behavior: HitTestBehavior.translucent,
-                child: MetadataWidget(
+                child: UserMetadataWidget(
                   pubkey: contact.publicKey,
-                  metadata: metadata,
+                  user: user,
                   jumpable: true,
                 ),
               );
             },
             selector: (context, provider) {
-              return provider.getMetadata(contact.publicKey);
+              return provider.getUser(contact.publicKey);
             },
           ),
         );

--- a/lib/router/user/contact_list_widget.dart
+++ b/lib/router/user/contact_list_widget.dart
@@ -6,7 +6,7 @@ import '../../component/user/user_metadata_widget.dart';
 import '../../consts/base.dart';
 import '../../consts/router_path.dart';
 import '../../data/user.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../../util/router_util.dart';
 import '../../util/table_mode_util.dart';
 
@@ -36,7 +36,7 @@ class _ContactListWidgetState extends State<ContactListWidget> {
         var contact = list![index];
         return Container(
           margin: const EdgeInsets.only(bottom: Base.basePaddingHalf),
-          child: Selector<MetadataProvider, User?>(
+          child: Selector<UserProvider, User?>(
             builder: (context, user, child) {
               return GestureDetector(
                 onTap: () {

--- a/lib/router/user/followed_widget.dart
+++ b/lib/router/user/followed_widget.dart
@@ -3,10 +3,10 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:provider/provider.dart';
 
 import '../../component/appbar_back_btn_widget.dart';
-import '../../component/user/metadata_widget.dart';
+import '../../component/user/user_metadata_widget.dart';
 import '../../consts/base.dart';
 import '../../consts/router_path.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../generated/l10n.dart';
 import '../../provider/metadata_provider.dart';
 import '../../util/router_util.dart';
@@ -54,22 +54,22 @@ class _FollowedWidgetState extends State<FollowedWidget> {
 
         return Container(
           margin: const EdgeInsets.only(bottom: Base.basePaddingHalf),
-          child: Selector<MetadataProvider, Metadata?>(
-            builder: (context, metadata, child) {
+          child: Selector<MetadataProvider, User?>(
+            builder: (context, user, child) {
               return GestureDetector(
                 onTap: () {
                   RouterUtil.router(context, RouterPath.USER, pubkey);
                 },
                 behavior: HitTestBehavior.translucent,
-                child: MetadataWidget(
+                child: UserMetadataWidget(
                   pubkey: pubkey,
-                  metadata: metadata,
+                  user: user,
                   jumpable: true,
                 ),
               );
             },
             selector: (_, provider) {
-              return provider.getMetadata(pubkey);
+              return provider.getUser(pubkey);
             },
           ),
         );

--- a/lib/router/user/followed_widget.dart
+++ b/lib/router/user/followed_widget.dart
@@ -8,7 +8,7 @@ import '../../consts/base.dart';
 import '../../consts/router_path.dart';
 import '../../data/user.dart';
 import '../../generated/l10n.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../../util/router_util.dart';
 
 import '../../util/table_mode_util.dart';
@@ -54,7 +54,7 @@ class _FollowedWidgetState extends State<FollowedWidget> {
 
         return Container(
           margin: const EdgeInsets.only(bottom: Base.basePaddingHalf),
-          child: Selector<MetadataProvider, User?>(
+          child: Selector<UserProvider, User?>(
             builder: (context, user, child) {
               return GestureDetector(
                 onTap: () {

--- a/lib/router/user/user_statistics_widget.dart
+++ b/lib/router/user/user_statistics_widget.dart
@@ -7,7 +7,7 @@ import 'package:nostrmo/component/enum_selector_widget.dart';
 import 'package:nostrmo/consts/base_consts.dart';
 import 'package:nostrmo/provider/contact_list_provider.dart';
 import 'package:nostrmo/provider/list_provider.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import 'package:nostrmo/provider/relay_provider.dart';
 import 'package:provider/provider.dart';
 
@@ -150,7 +150,7 @@ class _UserStatisticsWidgetState extends CustState<UserStatisticsWidget> {
         ),
       );
     } else {
-      var provider = Provider.of<MetadataProvider>(context);
+      var provider = Provider.of<UserProvider>(context);
       contactList = provider.getContactList(pubkey!);
 
       List<Widget> list = [];
@@ -291,7 +291,7 @@ class _UserStatisticsWidgetState extends CustState<UserStatisticsWidget> {
         RouterUtil.router(context, RouterPath.USER_CONTACT_LIST, cl);
       }
     } else {
-      var contactList = metadataProvider.getContactList(pubkey!);
+      var contactList = userProvider.getContactList(pubkey!);
       if (contactList != null) {
         RouterUtil.router(context, RouterPath.USER_CONTACT_LIST, contactList);
       }

--- a/lib/router/user/user_widget.dart
+++ b/lib/router/user/user_widget.dart
@@ -11,9 +11,9 @@ import 'package:provider/provider.dart';
 import '../../component/appbar4stack.dart';
 import '../../component/cust_state.dart';
 import '../../component/event/event_list_widget.dart';
-import '../../component/user/metadata_widget.dart';
+import '../../component/user/user_metadata_widget.dart';
 import '../../consts/base_consts.dart';
-import '../../data/metadata.dart';
+import '../../data/user.dart';
 import '../../main.dart';
 import '../../provider/metadata_provider.dart';
 import '../../provider/settings_provider.dart';
@@ -116,14 +116,14 @@ class _UserWidgetState extends CustState<UserWidget>
 
     final themeData = Theme.of(context);
 
-    return Selector<MetadataProvider, Metadata?>(
+    return Selector<MetadataProvider, User?>(
       shouldRebuild: (previous, next) {
         return previous != next;
       },
       selector: (context, metadataProvider) {
-        return metadataProvider.getMetadata(pubkey!);
+        return metadataProvider.getUser(pubkey!);
       },
-      builder: (context, metadata, child) {
+      builder: (context, user, child) {
         Color? appbarBackgroundColor = Colors.transparent;
         if (showAppbarBG) {
           appbarBackgroundColor = themeData.cardColor.withOpacity(0.6);
@@ -131,7 +131,7 @@ class _UserWidgetState extends CustState<UserWidget>
         Widget? appbarTitle;
         if (showTitle) {
           String displayName =
-              SimpleNameWidget.getSimpleName(pubkey!, metadata);
+              SimpleNameWidget.getSimpleName(pubkey!, user);
 
           appbarTitle = Container(
             alignment: Alignment.center,
@@ -157,9 +157,9 @@ class _UserWidgetState extends CustState<UserWidget>
           headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
             return <Widget>[
               SliverToBoxAdapter(
-                child: MetadataWidget(
+                child: UserMetadataWidget(
                   pubkey: pubkey!,
-                  metadata: metadata,
+                  user: user,
                   showBadges: true,
                   userPicturePreview: true,
                 ),

--- a/lib/router/user/user_widget.dart
+++ b/lib/router/user/user_widget.dart
@@ -15,7 +15,7 @@ import '../../component/user/user_metadata_widget.dart';
 import '../../consts/base_consts.dart';
 import '../../data/user.dart';
 import '../../main.dart';
-import '../../provider/metadata_provider.dart';
+import '../../provider/user_provider.dart';
 import '../../provider/settings_provider.dart';
 import '../../util/load_more_event.dart';
 import '../../util/router_util.dart';
@@ -116,12 +116,12 @@ class _UserWidgetState extends CustState<UserWidget>
 
     final themeData = Theme.of(context);
 
-    return Selector<MetadataProvider, User?>(
+    return Selector<UserProvider, User?>(
       shouldRebuild: (previous, next) {
         return previous != next;
       },
       selector: (context, metadataProvider) {
-        return metadataProvider.getUser(pubkey!);
+        return userProvider.getUser(pubkey!);
       },
       builder: (context, user, child) {
         Color? appbarBackgroundColor = Colors.transparent;
@@ -254,7 +254,7 @@ class _UserWidgetState extends CustState<UserWidget>
   }
 
   void updateUserdata() {
-    metadataProvider.update(pubkey!);
+    userProvider.update(pubkey!);
   }
 
   void onEvent(event) {
@@ -326,7 +326,7 @@ class _UserWidgetState extends CustState<UserWidget>
       // this is init query
       // try to query from user's write relay.
       List<String>? tempRelays =
-          metadataProvider.getExtralRelays(pubkey!, true);
+          userProvider.getExtralRelays(pubkey!, true);
       // the init page set to very small, due to open user page very often
       filter.limit = 10;
       nostr!.query([filter.toJson()], onEventFunc,

--- a/lib/util/zap_action.dart
+++ b/lib/util/zap_action.dart
@@ -44,8 +44,8 @@ class ZapAction {
       BuildContext context, int sats, String pubkey,
       {String? eventId, String? pollOption, String? comment}) async {
     final localization = S.of(context);
-    var metadata = metadataProvider.getMetadata(pubkey);
-    if (metadata == null) {
+    final user = metadataProvider.getUser(pubkey);
+    if (user == null) {
       BotToast.showText(text: localization.Metadata_can_not_be_found);
       return null;
     }
@@ -55,12 +55,12 @@ class ZapAction {
     // lud06 like: LNURL1DP68GURN8GHJ7MRW9E6XJURN9UH8WETVDSKKKMN0WAHZ7MRWW4EXCUP0XPURJCEKXVERVDEJXCMKYDFHV43KX2HK8GT
     // lud16 like: pavol@rusnak.io
     // but some people set lud16 to lud06
-    String? lnurl = metadata.lud06;
+    String? lnurl = user.lud06;
     String? lud16Link;
 
     if (StringUtil.isBlank(lnurl)) {
-      if (StringUtil.isNotBlank(metadata.lud16)) {
-        lnurl = Zap.getLnurlFromLud16(metadata.lud16!);
+      if (StringUtil.isNotBlank(user.lud16)) {
+        lnurl = Zap.getLnurlFromLud16(user.lud16!);
       }
     }
     if (StringUtil.isBlank(lnurl)) {
@@ -69,17 +69,17 @@ class ZapAction {
     }
     // check if user set wrong
     if (lnurl!.contains("@")) {
-      lnurl = Zap.getLnurlFromLud16(metadata.lud16!);
+      lnurl = Zap.getLnurlFromLud16(user.lud16!);
     }
 
     if (StringUtil.isBlank(lud16Link)) {
-      if (StringUtil.isNotBlank(metadata.lud16)) {
-        lud16Link = Zap.getLud16LinkFromLud16(metadata.lud16!);
+      if (StringUtil.isNotBlank(user.lud16)) {
+        lud16Link = Zap.getLud16LinkFromLud16(user.lud16!);
       }
     }
     if (StringUtil.isBlank(lud16Link)) {
-      if (StringUtil.isNotBlank(metadata.lud06)) {
-        lud16Link = Zap.decodeLud06Link(metadata.lud06!);
+      if (StringUtil.isNotBlank(user.lud06)) {
+        lud16Link = Zap.decodeLud06Link(user.lud06!);
       }
     }
 

--- a/lib/util/zap_action.dart
+++ b/lib/util/zap_action.dart
@@ -44,7 +44,7 @@ class ZapAction {
       BuildContext context, int sats, String pubkey,
       {String? eventId, String? pollOption, String? comment}) async {
     final localization = S.of(context);
-    final user = metadataProvider.getUser(pubkey);
+    final user = userProvider.getUser(pubkey);
     if (user == null) {
       BotToast.showText(text: localization.Metadata_can_not_be_found);
       return null;

--- a/test/sign_up_test.dart
+++ b/test/sign_up_test.dart
@@ -7,14 +7,14 @@ import 'package:mockito/mockito.dart';
 import 'package:nostr_sdk/relay/relay_info_util.dart';
 import 'package:nostrmo/main.dart';
 import 'package:nostrmo/generated/l10n.dart';
-import 'package:nostrmo/provider/metadata_provider.dart';
+import 'package:nostrmo/provider/user_provider.dart';
 import 'package:nostrmo/router/signup/signup_widget.dart';
 import 'package:nostrmo/router/group/no_communities_widget.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'sign_up_test.mocks.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
-@GenerateNiceMocks([MockSpec<http.Client>(), MockSpec<MetadataProvider>()])
+@GenerateNiceMocks([MockSpec<http.Client>(), MockSpec<UserProvider>()])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -57,7 +57,7 @@ void main() {
 
     await initializeProviders(isTesting: true);
 
-    metadataProvider = MockMetadataProvider();
+    userProvider = MockUserProvider();
 
     await relayLocalDB?.close();
     relayLocalDB = null;

--- a/test/sign_up_test.mocks.dart
+++ b/test/sign_up_test.mocks.dart
@@ -12,7 +12,7 @@ import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i5;
 import 'package:nostr_sdk/nostr_sdk.dart' as _i9;
-import 'package:nostrmo/data/metadata.dart' as _i8;
+import 'package:nostrmo/data/user.dart' as _i8;
 import 'package:nostrmo/provider/metadata_provider.dart' as _i7;
 
 // ignore_for_file: type=lint
@@ -414,7 +414,7 @@ class MockMetadataProvider extends _i1.Mock implements _i7.MetadataProvider {
       );
 
   @override
-  List<_i8.Metadata> findUser(
+  List<_i8.User> findUser(
     String? str, {
     int? limit = 5,
   }) =>
@@ -424,9 +424,9 @@ class MockMetadataProvider extends _i1.Mock implements _i7.MetadataProvider {
           [str],
           {#limit: limit},
         ),
-        returnValue: <_i8.Metadata>[],
-        returnValueForMissingStub: <_i8.Metadata>[],
-      ) as List<_i8.Metadata>);
+        returnValue: <_i8.User>[],
+        returnValueForMissingStub: <_i8.User>[],
+      ) as List<_i8.User>);
 
   @override
   void update(String? pubkey) => super.noSuchMethod(
@@ -438,13 +438,13 @@ class MockMetadataProvider extends _i1.Mock implements _i7.MetadataProvider {
       );
 
   @override
-  _i8.Metadata? getMetadata(String? pubkey) => (super.noSuchMethod(
+  _i8.User? getUser(String? pubkey) => (super.noSuchMethod(
         Invocation.method(
           #getMetadata,
           [pubkey],
         ),
         returnValueForMissingStub: null,
-      ) as _i8.Metadata?);
+      ) as _i8.User?);
 
   @override
   int getNip05Status(String? pubkey) => (super.noSuchMethod(

--- a/test/sign_up_test.mocks.dart
+++ b/test/sign_up_test.mocks.dart
@@ -440,7 +440,7 @@ class MockMetadataProvider extends _i1.Mock implements _i7.MetadataProvider {
   @override
   _i8.User? getUser(String? pubkey) => (super.noSuchMethod(
         Invocation.method(
-          #getMetadata,
+          #getUser,
           [pubkey],
         ),
         returnValueForMissingStub: null,

--- a/test/sign_up_test.mocks.dart
+++ b/test/sign_up_test.mocks.dart
@@ -13,7 +13,7 @@ import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i5;
 import 'package:nostr_sdk/nostr_sdk.dart' as _i9;
 import 'package:nostrmo/data/user.dart' as _i8;
-import 'package:nostrmo/provider/metadata_provider.dart' as _i7;
+import 'package:nostrmo/provider/user_provider.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -370,10 +370,10 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 }
 
-/// A class which mocks [MetadataProvider].
+/// A class which mocks [UserProvider].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMetadataProvider extends _i1.Mock implements _i7.MetadataProvider {
+class MockUserProvider extends _i1.Mock implements _i7.UserProvider {
   @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/275

## Description
Renames `Metadata` to `User` to increase readability and maintainability where used throughout the app. Also helps to further distinguish from `GroupMetadata`.

No intended functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized how user information is managed and displayed across profiles, contact lists, event feeds, search, and other UI elements for a more consistent and reliable experience.
- **Documentation**
  - Updated terminology and in-app messaging to clearly reflect refined user data handling.
- **Tests**
  - Modified test cases to align with the updated user data model, ensuring continued stability and accuracy of user-related features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->