### PR TITLE
added Cancel button when adding accounts #254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the confirm button disabled color. [#279](https://github.com/verse-pbc/issues/issues/279)
 - Added Admin Panel. [#263](https://github.com/verse-pbc/issues/issues/263)
 - Made it easier to dismiss fullscreen images. [#286](https://github.com/verse-pbc/issues/issues/286)
+- Added Cancel button when adding accounts. [#254](https://github.com/verse-pbc/issues/issues/254)
 
 ### Internal Changes
 - Added functions to send push notification registration events to our relay. [#137](https://github.com/verse-pbc/plur/pull/137)

--- a/lib/router/login/login_widget.dart
+++ b/lib/router/login/login_widget.dart
@@ -312,6 +312,28 @@ class _LoginSignupState extends State<LoginSignupWidget> {
         child: Stack(
           alignment: AlignmentDirectional.center,
           children: [
+            if (backAfterLogin)
+              SafeArea(
+                child: Stack(
+                  children: [
+                    Positioned(
+                      top: 4,
+                      left: 4,
+                      child: TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        style: TextButton.styleFrom(
+                          textStyle: const TextStyle(
+                            fontSize: 16.0,
+                            fontWeight: FontWeight.w500,
+                          ),
+                          foregroundColor: themeData.customColors.accentColor,
+                        ),
+                        child: Text(localization.Cancel),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             SizedBox(
               // A `SizedBox` that constrains the width of the content.
               width: mainWidth,


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/254

## Description
Fixes the user trap issue when adding an extra account after the initial sign in by adding a cancel button.

Note: The cancel button is NOT added when the user is signing into their first account.

## How to test
1. Sign in to an account.
2. Navigate to the side menu.
3. Tap Account Manager at the bottom.
4. Tap Add Account.
At this point, if you want to cancel adding an account, you're stuck.

## Screenshots/Video

| Before | After |
|--------|--------|
|<img width="320" alt="before" src="https://github.com/user-attachments/assets/5c11c15f-6068-4d49-ad6d-7614bd08e5eb" />|<img width="320" alt="after" src="https://github.com/user-attachments/assets/06c9a6fc-a75d-4165-a70e-ea03c658801e" />|
|![before](https://github.com/user-attachments/assets/58720ba3-d768-4deb-a240-7033c199fd60)|![after](https://github.com/user-attachments/assets/d386e180-3c47-44fe-8a57-049718fde6fc)|



@Chardot Please review these UI changes to be sure they match the design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Cancel button during account creation, giving users an option to abort the process.
  - Added a conditional Cancel button on the login screen, allowing users to easily return to the previous screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->