### PR TITLE
Add ability to paste community join links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Admin Panel. [#263](https://github.com/verse-pbc/issues/issues/263)
 - Made it easier to dismiss fullscreen images. [#286](https://github.com/verse-pbc/issues/issues/286)
 - Added Cancel button when adding accounts. [#254](https://github.com/verse-pbc/issues/issues/254)
+- Added ability to paste community join links to join communities. [#284](https://github.com/verse-pbc/issues/issues/284)
 
 ### Internal Changes
 - Added functions to send push notification registration events to our relay. [#137](https://github.com/verse-pbc/plur/pull/137)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made it easier to dismiss fullscreen images. [#286](https://github.com/verse-pbc/issues/issues/286)
 - Added Cancel button when adding accounts. [#254](https://github.com/verse-pbc/issues/issues/254)
 - Added ability to paste community join links to join communities. [#284](https://github.com/verse-pbc/issues/issues/284)
+- Improved community join link feature with better error handling and validation. [#152](https://github.com/verse-pbc/plur/pull/152)
 
 ### Internal Changes
 - Added functions to send push notification registration events to our relay. [#137](https://github.com/verse-pbc/plur/pull/137)

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -243,6 +243,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Input parse error"),
         "Input_relay_address":
             MessageLookupByLibrary.simpleMessage("Input relay address."),
+        "Join": MessageLookupByLibrary.simpleMessage("Join"),
         "Join_Group": MessageLookupByLibrary.simpleMessage("Join Group"),
         "Language": MessageLookupByLibrary.simpleMessage("Language"),
         "Light": MessageLookupByLibrary.simpleMessage("Light"),
@@ -317,6 +318,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "PLease_input_NWC_URL":
             MessageLookupByLibrary.simpleMessage("PLease input NWC URL"),
         "Password": MessageLookupByLibrary.simpleMessage("Password"),
+        "Paste": MessageLookupByLibrary.simpleMessage("Paste from clipboard"),
         "Pay": MessageLookupByLibrary.simpleMessage("Pay"),
         "Picture": MessageLookupByLibrary.simpleMessage("Picture"),
         "Please_authenticate_to_turn_off_the_privacy_lock":

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3439,6 +3439,26 @@ class S {
       args: [number],
     );
   }
+
+  /// `Join`
+  String get Join {
+    return Intl.message(
+      'Join',
+      name: 'Join',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Paste from clipboard`
+  String get Paste {
+    return Intl.message(
+      'Paste from clipboard',
+      name: 'Paste',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -351,5 +351,7 @@
           "type": "int"
         }
       }
-    }
+    },
+    "Join": "Join",
+    "Paste": "Paste from clipboard"
 }

--- a/lib/router/group/create_community_dialog.dart
+++ b/lib/router/group/create_community_dialog.dart
@@ -1,11 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostrmo/generated/l10n.dart';
 import 'package:nostrmo/router/group/create_community_widget.dart';
+import 'package:nostrmo/router/group/join_community_widget.dart';
 import 'package:nostrmo/util/router_util.dart';
 import 'package:nostrmo/util/theme_util.dart';
 import 'package:nostrmo/router/group/invite_people_widget.dart';
 import 'package:nostrmo/provider/list_provider.dart';
+import 'package:nostrmo/data/join_group_parameters.dart';
 import 'package:provider/provider.dart';
+
+// Track which view is currently active
+enum DialogView {
+  chooseOption,  // Initial choice screen
+  createCommunity, // Create a new community
+  joinCommunity,  // Join existing community
+  invitePeople  // Show invite people after creation
+}
 
 class CreateCommunityDialog extends StatefulWidget {
   const CreateCommunityDialog({super.key});
@@ -25,9 +36,10 @@ class CreateCommunityDialog extends StatefulWidget {
 }
 
 class _CreateCommunityDialogState extends State<CreateCommunityDialog> {
-  bool _showInviteCommunity = false;
   String? _communityInviteLink;
   GroupIdentifier? _groupIdentifier;
+  
+  DialogView _currentView = DialogView.chooseOption;
 
   @override
   Widget build(BuildContext context) {
@@ -73,10 +85,16 @@ class _CreateCommunityDialogState extends State<CreateCommunityDialog> {
                           },
                         ),
                       ),
-                      if (!_showInviteCommunity)
+                      // Show different content based on current view
+                      if (_currentView == DialogView.chooseOption)
+                        _buildOptionChoiceView(themeData),
+                      if (_currentView == DialogView.createCommunity)
                         CreateCommunityWidget(
                             onCreateCommunity: _onCreateCommunity),
-                      if (_showInviteCommunity)
+                      if (_currentView == DialogView.joinCommunity)
+                        JoinCommunityWidget(
+                            onJoinCommunity: _onJoinCommunity),
+                      if (_currentView == DialogView.invitePeople)
                         InvitePeopleWidget(
                           shareableLink: _communityInviteLink ?? '',
                           groupIdentifier: _groupIdentifier!,
@@ -92,7 +110,108 @@ class _CreateCommunityDialogState extends State<CreateCommunityDialog> {
       ),
     );
   }
+  
+  // Build the option choice view with two buttons
+  Widget _buildOptionChoiceView(ThemeData themeData) {
+    final l10n = S.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text(
+          l10n.Communities,
+          style: const TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 20,
+          ),
+        ),
+        const SizedBox(height: 30),
+        // Create new community option
+        _buildOptionButton(
+          icon: Icons.add_circle_outline,
+          title: l10n.Create_Group,
+          description: "Start a private community that you'll be the admin of",
+          onTap: () {
+            setState(() {
+              _currentView = DialogView.createCommunity;
+            });
+          },
+          themeData: themeData,
+        ),
+        const SizedBox(height: 15),
+        // Join existing community option
+        _buildOptionButton(
+          icon: Icons.group_add,
+          title: l10n.Join_Group,
+          description: "Paste an invitation link to join a community",
+          onTap: () {
+            setState(() {
+              _currentView = DialogView.joinCommunity;
+            });
+          },
+          themeData: themeData,
+        ),
+      ],
+    );
+  }
+  
+  // Helper to build consistent option buttons
+  Widget _buildOptionButton({
+    required IconData icon,
+    required String title,
+    required String description,
+    required VoidCallback onTap,
+    required ThemeData themeData,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(15),
+        decoration: BoxDecoration(
+          color: themeData.cardColor,
+          border: Border.all(color: themeData.dividerColor.withOpacity(0.5)),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, size: 30, color: themeData.primaryColor),
+            const SizedBox(width: 15),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    description,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: themeData.textTheme.bodyMedium?.color?.withOpacity(0.7),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              Icons.arrow_forward_ios,
+              size: 16,
+              color: themeData.iconTheme.color?.withOpacity(0.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 
+  // Handle creating a new community
   void _onCreateCommunity(String communityName) async {
     final listProvider = Provider.of<ListProvider>(context, listen: false);
     final groupDetails =
@@ -101,7 +220,49 @@ class _CreateCommunityDialogState extends State<CreateCommunityDialog> {
     setState(() {
       _communityInviteLink = groupDetails.$1;
       _groupIdentifier = groupDetails.$2;
-      _showInviteCommunity = true;
+      _currentView = DialogView.invitePeople;
     });
+  }
+  
+  // Handle joining an existing community
+  void _onJoinCommunity(String joinLink) async {
+    // Parse the link
+    try {
+      Uri uri = Uri.parse(joinLink.trim());
+      if (uri.scheme.toLowerCase() == 'plur' && uri.host.toLowerCase() == 'join-community') {
+        String? groupId = uri.queryParameters['group-id'];
+        String? code = uri.queryParameters['code'];
+
+        if (groupId == null || groupId.isEmpty) {
+          _showError("Invalid community link. Missing group ID.");
+          return;
+        }
+
+        final listProvider = Provider.of<ListProvider>(context, listen: false);
+        
+        // Join the group using the existing method
+        listProvider.joinGroup(
+          JoinGroupParameters(
+            'wss://communities.nos.social', // Default relay
+            groupId,
+            code: code,
+          ),
+          context: context,
+        );
+        
+        // Close the dialog
+        RouterUtil.back(context);
+      } else {
+        _showError("Invalid community link format. Please check and try again.");
+      }
+    } catch (e) {
+      _showError("Could not process the community link. Please check and try again.");
+    }
+  }
+  
+  void _showError(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message), duration: const Duration(seconds: 3)),
+    );
   }
 }

--- a/lib/router/group/create_community_widget.dart
+++ b/lib/router/group/create_community_widget.dart
@@ -18,7 +18,25 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
   @override
   Widget build(BuildContext context) {
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // Back button in top left
+        Align(
+          alignment: Alignment.topLeft,
+          child: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () {
+              // Go back to the option selection screen
+              FocusScope.of(context).unfocus();
+              Navigator.of(context).maybePop();
+            },
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            splashRadius: 24,
+          ),
+        ),
+        const SizedBox(height: 10),
+        
         const Text(
           "Create your community",
           style: TextStyle(

--- a/lib/router/group/join_community_widget.dart
+++ b/lib/router/group/join_community_widget.dart
@@ -30,9 +30,7 @@ class _JoinCommunityWidgetState extends State<JoinCommunityWidget> {
     final clipboardText = clipboardData?.text?.trim();
     
     // If clipboard contains what looks like a community link, pre-fill it
-    if (clipboardText != null && 
-        clipboardText.startsWith('plur://join-community') &&
-        clipboardText.contains('group-id=')) {
+    if (clipboardText != null && isValidCommunityLink(clipboardText)) {
       _linkController.text = clipboardText;
       _validateLink(clipboardText);
     }
@@ -40,10 +38,15 @@ class _JoinCommunityWidgetState extends State<JoinCommunityWidget> {
   
   void _validateLink(String text) {
     setState(() {
-      // Basic validation - we'll do more thorough validation when processing
-      _hasValidFormat = text.trim().startsWith('plur://join-community') && 
-                       text.contains('group-id=');
+      // Use utility function for validation
+      _hasValidFormat = isValidCommunityLink(text.trim());
     });
+  }
+  
+  // Utility function to validate community links
+  bool isValidCommunityLink(String link) {
+    return link.startsWith('plur://join-community') && 
+           link.contains('group-id=');
   }
 
   @override

--- a/lib/router/group/join_community_widget.dart
+++ b/lib/router/group/join_community_widget.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:nostrmo/component/primary_button_widget.dart';
+import 'package:nostrmo/generated/l10n.dart';
+
+/// A widget that provides a UI for joining an existing community by pasting an invitation link.
+class JoinCommunityWidget extends StatefulWidget {
+  final void Function(String) onJoinCommunity;
+
+  const JoinCommunityWidget({super.key, required this.onJoinCommunity});
+
+  @override
+  State<JoinCommunityWidget> createState() => _JoinCommunityWidgetState();
+}
+
+class _JoinCommunityWidgetState extends State<JoinCommunityWidget> {
+  final TextEditingController _linkController = TextEditingController();
+  bool _hasValidFormat = false;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    // Check clipboard on initialization
+    _checkClipboard();
+  }
+  
+  Future<void> _checkClipboard() async {
+    final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+    final clipboardText = clipboardData?.text?.trim();
+    
+    // If clipboard contains what looks like a community link, pre-fill it
+    if (clipboardText != null && 
+        clipboardText.startsWith('plur://join-community') &&
+        clipboardText.contains('group-id=')) {
+      _linkController.text = clipboardText;
+      _validateLink(clipboardText);
+    }
+  }
+  
+  void _validateLink(String text) {
+    setState(() {
+      // Basic validation - we'll do more thorough validation when processing
+      _hasValidFormat = text.trim().startsWith('plur://join-community') && 
+                       text.contains('group-id=');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = S.of(context);
+    
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Back button in top left
+        Align(
+          alignment: Alignment.topLeft,
+          child: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () {
+              // Go back to the option selection screen
+              FocusScope.of(context).unfocus();
+              Navigator.of(context).maybePop();
+            },
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            splashRadius: 24,
+          ),
+        ),
+        const SizedBox(height: 10),
+        
+        Text(
+          l10n.Join_Group,
+          style: const TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 20,
+          ),
+        ),
+        const SizedBox(height: 20),
+        
+        Text(
+          "Paste a community invitation link",
+          style: const TextStyle(
+            fontSize: 16,
+          ),
+        ),
+        const SizedBox(height: 8),
+        
+        // Example of what a link looks like
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: Colors.grey.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: const Text(
+            "Example: plur://join-community?group-id=ABC123&code=XYZ789",
+            style: TextStyle(
+              fontSize: 12,
+              fontFamily: 'monospace',
+              color: Colors.grey,
+            ),
+          ),
+        ),
+        const SizedBox(height: 15),
+        
+        // Link input field
+        TextField(
+          controller: _linkController,
+          maxLines: 3,
+          minLines: 1,
+          decoration: InputDecoration(
+            hintText: l10n.Please_input,
+            border: const OutlineInputBorder(),
+            suffixIcon: _linkController.text.isNotEmpty 
+              ? IconButton(
+                  icon: const Icon(Icons.clear),
+                  onPressed: () {
+                    setState(() {
+                      _linkController.clear();
+                      _hasValidFormat = false;
+                    });
+                  },
+                )
+              : null,
+          ),
+          onChanged: _validateLink,
+        ),
+        const SizedBox(height: 10),
+        
+        // Paste button
+        Center(
+          child: TextButton.icon(
+            onPressed: () async {
+              final data = await Clipboard.getData(Clipboard.kTextPlain);
+              if (data?.text != null) {
+                _linkController.text = data!.text!.trim();
+                _validateLink(_linkController.text);
+              }
+            },
+            icon: const Icon(Icons.content_paste),
+            label: Text(l10n.Paste),
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            ),
+          ),
+        ),
+        const SizedBox(height: 20),
+        
+        // Join button
+        PrimaryButtonWidget(
+          text: l10n.Join,
+          onTap: _hasValidFormat 
+            ? () => widget.onJoinCommunity(_linkController.text) 
+            : null,
+          enabled: _hasValidFormat,
+        ),
+      ],
+    );
+  }
+  
+  @override
+  void dispose() {
+    _linkController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/router/group/join_community_widget.dart
+++ b/lib/router/group/join_community_widget.dart
@@ -83,9 +83,9 @@ class _JoinCommunityWidgetState extends State<JoinCommunityWidget> {
         ),
         const SizedBox(height: 20),
         
-        Text(
+        const Text(
           "Paste a community invitation link",
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 16,
           ),
         ),
@@ -96,7 +96,7 @@ class _JoinCommunityWidgetState extends State<JoinCommunityWidget> {
           width: double.infinity,
           padding: const EdgeInsets.all(8),
           decoration: BoxDecoration(
-            color: Colors.grey.withOpacity(0.1),
+            color: Colors.grey.withAlpha(25), // Equivalent to opacity 0.1
             borderRadius: BorderRadius.circular(4),
           ),
           child: const Text(


### PR DESCRIPTION
## Summary
- Implemented a feature allowing users to paste community join links rather than having to click them directly
- Created a clear UI with two options: create a new community or join an existing one
- Added clipboard detection to automatically pre-fill community join links
- Improved error handling and validation for community links

## Test plan
1. Open the Communities tab
2. Click the "+" button to create/join a community
3. Select "Join an existing community"
4. Test pasting a valid community link (format: plur://join-community?group-id=ABC123&code=XYZ789)
5. Test error handling with invalid link formats
6. Verify the join process completes successfully

Fixes #284

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Users can now paste invitation links to join communities.
	- Enjoy an enhanced interface that clearly separates options for creating, joining, and inviting community members.
	- A dedicated widget with clipboard integration and link validation streamlines the join process.
	- Improved navigation with a new back button for an easier return to previous screens.
- **Documentation**
	- Updated release notes to reflect new features and improvements in community join functionality.
	- Added entries detailing enhanced error handling and validation for community join links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->