### PR TITLE
Fix withOpacity deprecation warnings

### DIFF
--- a/fix_withOpacity.sh
+++ b/fix_withOpacity.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This script replaces all occurrences of withOpacity() with withAlpha()
+# and dynamically calculates the appropriate alpha value (opacity * 255).
+
+# Find all Dart files with withOpacity
+find lib -type f -name "*.dart" | xargs grep -l "withOpacity" > files.txt
+
+while IFS= read -r file; do
+  echo "Processing $file"
+  
+  # Create a temporary file
+  temp_file="${file}.tmp"
+  
+  # Read the file line by line
+  while IFS= read -r line; do
+    # Check if the line contains withOpacity
+    if [[ "$line" == *".withOpacity("* ]]; then
+      # Extract all withOpacity occurrences in the line
+      while [[ "$line" =~ (.*)\.withOpacity\(([0-9]*\.[0-9]+)\)(.*) ]]; do
+        prefix="${BASH_REMATCH[1]}"
+        opacity="${BASH_REMATCH[2]}"
+        suffix="${BASH_REMATCH[3]}"
+        
+        # Calculate alpha value (opacity * 255, rounded to nearest integer)
+        alpha=$(echo "$opacity * 255" | bc -l | xargs printf "%.0f")
+        
+        # Replace withOpacity with withAlpha
+        line="${prefix}.withAlpha(${alpha})${suffix}"
+      done
+    fi
+    
+    # Write the line to the temporary file
+    echo "$line" >> "$temp_file"
+  done < "$file"
+  
+  # Replace the original file with the temporary file
+  mv "$temp_file" "$file"
+  
+done < files.txt
+
+# Cleanup
+rm files.txt
+
+echo "All withOpacity calls have been replaced with withAlpha!"

--- a/lib/component/add_btn_wrapper_widget.dart
+++ b/lib/component/add_btn_wrapper_widget.dart
@@ -164,7 +164,7 @@ class AddBtnStartItemButton extends StatelessWidget {
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.2),
+              color: Colors.black.withAlpha(51),
               offset: const Offset(2, 5),
               blurRadius: 10,
               spreadRadius: 0,

--- a/lib/component/blurhash_image_component/blurhash_image_component_io.dart
+++ b/lib/component/blurhash_image_component/blurhash_image_component_io.dart
@@ -14,7 +14,7 @@ Widget? genBlurhashImageWidget(
       decodingHeight: height, decodingWidth: width);
 
   return Container(
-    color: color.withOpacity(0.2),
+    color: color.withAlpha(51),
     child: AspectRatio(
       aspectRatio: 1.6,
       child: Image(

--- a/lib/component/color_pick_dialog.dart
+++ b/lib/component/color_pick_dialog.dart
@@ -56,7 +56,7 @@ class _ColorPickDialogState extends State<ColorPickDialog> {
           onTap: () {
             RouterUtil.back(context, selectedColor);
           },
-          highlightColor: mainColor.withOpacity(0.2),
+          highlightColor: mainColor.withAlpha(51),
           child: Container(
             color: mainColor,
             height: 40,

--- a/lib/component/colors_selector_widget.dart
+++ b/lib/component/colors_selector_widget.dart
@@ -48,7 +48,7 @@ class ColorSelectorWidget extends StatelessWidget {
         ));
 
     return Scaffold(
-      backgroundColor: Colors.black.withOpacity(0.2),
+      backgroundColor: Colors.black.withAlpha(51),
       body: FocusScope(
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,

--- a/lib/component/content/content_cashu_widget.dart
+++ b/lib/component/content/content_cashu_widget.dart
@@ -30,7 +30,7 @@ class ContentCashuWidget extends StatelessWidget {
         color: cardColor,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.2),
+            color: Colors.black.withAlpha(51),
             offset: const Offset(0, 0),
             blurRadius: 10,
             spreadRadius: 0,

--- a/lib/component/content/content_lnbc_widget.dart
+++ b/lib/component/content/content_lnbc_widget.dart
@@ -32,7 +32,7 @@ class ContentLnbcWidget extends StatelessWidget {
         color: cardColor,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.2),
+            color: Colors.black.withAlpha(51),
             offset: const Offset(0, 0),
             blurRadius: 10,
             spreadRadius: 0,

--- a/lib/component/content/content_widget.dart
+++ b/lib/component/content/content_widget.dart
@@ -199,7 +199,7 @@ class _ContentWidgetState extends State<ContentWidget> {
     largetFontSize = themeData.textTheme.bodyLarge!.fontSize!;
     iconWidgetWidth = largetFontSize + 4;
     hintColor = themeData.hintColor;
-    codeBackgroundColor = hintColor!.withOpacity(0.25);
+    codeBackgroundColor = hintColor!.withAlpha(64);
     var settingsProvider = Provider.of<SettingsProvider>(context);
     mdh1Style = TextStyle(
       fontSize: largetFontSize + 1,
@@ -283,7 +283,7 @@ class _ContentWidgetState extends State<ContentWidget> {
                   alignment: Alignment.centerRight,
                   padding: const EdgeInsets.only(right: Base.basePadding),
                   height: 30,
-                  color: themeData.cardColor.withOpacity(0.85),
+                  color: themeData.cardColor.withAlpha(217),
                   child: Text(
                     localization.Show_more,
                     style: TextStyle(

--- a/lib/component/datetime_picker_widget.dart
+++ b/lib/component/datetime_picker_widget.dart
@@ -113,7 +113,7 @@ class _DatetimePickerWidgetState extends State<DatetimePickerWidget> {
             calendarStyle: CalendarStyle(
               rangeHighlightColor: mainColor,
               selectedDecoration: BoxDecoration(
-                color: mainColor.withOpacity(0.8),
+                color: mainColor.withAlpha(204),
                 shape: BoxShape.circle,
               ),
               todayTextStyle: const TextStyle(
@@ -202,7 +202,7 @@ class _DatetimePickerWidgetState extends State<DatetimePickerWidget> {
     );
 
     return Scaffold(
-      backgroundColor: Colors.black.withOpacity(0.2),
+      backgroundColor: Colors.black.withAlpha(51),
       body: FocusScope(
         // Overlay 中 textField autoFocus 需要包一层 FocusScope
         node: _focusScopeNode,

--- a/lib/component/editor/custom_emoji_add_dialog.dart
+++ b/lib/component/editor/custom_emoji_add_dialog.dart
@@ -102,7 +102,7 @@ class _CustomEmojiAddDialog extends State<CustomEmojiAddDialog> {
           onTap: () {
             _onConfirm();
           },
-          highlightColor: mainColor.withOpacity(0.2),
+          highlightColor: mainColor.withAlpha(51),
           child: Container(
             color: mainColor,
             height: 40,

--- a/lib/component/editor/editor_mixin.dart
+++ b/lib/component/editor/editor_mixin.dart
@@ -271,7 +271,7 @@ mixin EditorMixin {
         boxShadow: showShadow
             ? [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.2),
+                  color: Colors.black.withAlpha(51),
                   offset: const Offset(0, -5),
                   blurRadius: 10,
                   spreadRadius: 0,
@@ -1137,7 +1137,7 @@ mixin EditorMixin {
           hintStyle: TextStyle(
             fontSize: fontSize,
             fontWeight: FontWeight.normal,
-            color: hintColor.withOpacity(0.8),
+            color: hintColor.withAlpha(204),
           ),
           counterText: "",
         ),
@@ -1221,7 +1221,7 @@ mixin EditorMixin {
           hintStyle: TextStyle(
             fontSize: fontSize,
             fontWeight: FontWeight.normal,
-            color: hintColor.withOpacity(0.8),
+            color: hintColor.withAlpha(204),
           ),
           counterText: "",
         ),

--- a/lib/component/editor/gen_lnbc_widget.dart
+++ b/lib/component/editor/gen_lnbc_widget.dart
@@ -124,7 +124,7 @@ class _GenLnbcWidgetState extends State<GenLnbcWidget> {
               onTap: () {
                 _onConfirm(user.pubkey!);
               },
-              highlightColor: mainColor.withOpacity(0.2),
+              highlightColor: mainColor.withAlpha(51),
               child: Container(
                 color: mainColor,
                 height: 40,

--- a/lib/component/editor/text_input_dialog_inner_widget.dart
+++ b/lib/component/editor/text_input_dialog_inner_widget.dart
@@ -76,7 +76,7 @@ class _TextInputDialogInnerWidgetState
         decoration: BoxDecoration(color: mainColor),
         child: InkWell(
           onTap: _onConfirm,
-          highlightColor: mainColor.withOpacity(0.2),
+          highlightColor: mainColor.withAlpha(51),
           child: Container(
             color: mainColor,
             height: 40,

--- a/lib/component/enum_multi_selector_widget.dart
+++ b/lib/component/enum_multi_selector_widget.dart
@@ -97,7 +97,7 @@ class _EnumMultiSelectorWidgetState extends State<EnumMultiSelectorWidget> {
       enumObj: enumObj,
       isLast: isLast,
       onTap: onTap,
-      color: exist ? Colors.blue.withOpacity(0.2) : null,
+      color: exist ? Colors.blue.withAlpha(51) : null,
     );
   }
 

--- a/lib/component/enum_selector_widget.dart
+++ b/lib/component/enum_selector_widget.dart
@@ -70,7 +70,7 @@ class EnumSelectorWidget extends StatelessWidget {
     );
 
     return Scaffold(
-      backgroundColor: Colors.black.withOpacity(0.2),
+      backgroundColor: Colors.black.withAlpha(51),
       body: FocusScope(
         // autofocus: true,
         child: GestureDetector(

--- a/lib/component/event/event_bitcoin_icon_widget.dart
+++ b/lib/component/event/event_bitcoin_icon_widget.dart
@@ -9,14 +9,14 @@ class EventBitcoinIconWidget extends StatelessWidget {
       decoration: BoxDecoration(
         border: Border.all(
           width: 8,
-          color: Colors.amber[600]!.withOpacity(0.5),
+          color: Colors.amber[600]!.withAlpha(128),
           style: BorderStyle.solid,
         ),
         borderRadius: BorderRadius.circular(54),
       ),
       child: Icon(
         Icons.currency_bitcoin,
-        color: Colors.amber[600]!.withOpacity(0.5),
+        color: Colors.amber[600]!.withAlpha(128),
         size: 100,
       ),
     );

--- a/lib/component/event/event_poll_widget.dart
+++ b/lib/component/event/event_poll_widget.dart
@@ -35,7 +35,7 @@ class _EventPollWidgetState extends State<EventPollWidget> {
     final localization = S.of(context);
     final themeData = Theme.of(context);
     var hintColor = themeData.hintColor;
-    var pollBackgroundColor = hintColor.withOpacity(0.3);
+    var pollBackgroundColor = hintColor.withAlpha(76);
     var mainColor = themeData.primaryColor;
 
     return Selector<EventReactionsProvider, EventReactions?>(
@@ -144,7 +144,7 @@ class _EventPollWidgetState extends State<EventPollWidget> {
                       widthFactor: percent,
                       child: Container(
                         decoration: BoxDecoration(
-                          color: mainColor.withOpacity(0.4),
+                          color: mainColor.withAlpha(102),
                           borderRadius: BorderRadius.circular(4),
                         ),
                       ),

--- a/lib/component/event/event_zap_goals_widget.dart
+++ b/lib/component/event/event_zap_goals_widget.dart
@@ -35,7 +35,7 @@ class _EventZapGoalsWidgetState extends State<EventZapGoalsWidget> {
     final localization = S.of(context);
     final themeData = Theme.of(context);
     var hintColor = themeData.hintColor;
-    var pollBackgroundColor = hintColor.withOpacity(0.3);
+    var pollBackgroundColor = hintColor.withAlpha(76);
     var mainColor = themeData.primaryColor;
 
     return Selector<EventReactionsProvider, EventReactions?>(
@@ -92,7 +92,7 @@ class _EventZapGoalsWidgetState extends State<EventZapGoalsWidget> {
                     widthFactor: percent,
                     child: Container(
                       decoration: BoxDecoration(
-                        color: mainColor.withOpacity(0.4),
+                        color: mainColor.withAlpha(102),
                         borderRadius: BorderRadius.circular(4),
                       ),
                     ),

--- a/lib/component/image_preview_dialog.dart
+++ b/lib/component/image_preview_dialog.dart
@@ -127,7 +127,7 @@ class _ImagePreviewDialog extends State<ImagePreviewDialog> {
     final localization = S.of(context);
 
     var main = Scaffold(
-      backgroundColor: widget.backgroundColor.withOpacity(0.5),
+      backgroundColor: widget.backgroundColor.withAlpha(128),
       body: GestureDetector(
         onTap: _close,
         child: Stack(

--- a/lib/component/json_view_dialog.dart
+++ b/lib/component/json_view_dialog.dart
@@ -89,7 +89,7 @@ class _JsonViewDialog extends State<JsonViewDialog> {
             _doCopy(widget.jsonText);
             RouterUtil.back(context);
           },
-          highlightColor: mainColor.withOpacity(0.2),
+          highlightColor: mainColor.withAlpha(51),
           child: Container(
             color: mainColor,
             height: 40,

--- a/lib/component/lightning_qrcode_dialog.dart
+++ b/lib/component/lightning_qrcode_dialog.dart
@@ -81,7 +81,7 @@ class _LightningQrcodeDialog extends State<LightningQrcodeDialog> {
           bottom: Base.basePaddingHalf,
         ),
         decoration: BoxDecoration(
-          color: hintColor.withOpacity(0.5),
+          color: hintColor.withAlpha(128),
           borderRadius: BorderRadius.circular(10),
         ),
         child: SelectableText(

--- a/lib/component/main_btn_widget.dart
+++ b/lib/component/main_btn_widget.dart
@@ -20,7 +20,7 @@ class MainBtnWidget extends StatelessWidget {
             onTap!();
           }
         },
-        highlightColor: mainColor.withOpacity(0.2),
+        highlightColor: mainColor.withAlpha(51),
         child: Container(
           color: mainColor,
           height: 40,

--- a/lib/component/music/music_widget.dart
+++ b/lib/component/music/music_widget.dart
@@ -62,7 +62,7 @@ class _MusicWidgetState extends State<MusicWidget> {
       imageWidget = Container(
         width: imageHeight,
         height: imageHeight,
-        color: themeData.hintColor.withOpacity(0.5),
+        color: themeData.hintColor.withAlpha(128),
       );
     }
 

--- a/lib/component/nip07_dialog.dart
+++ b/lib/component/nip07_dialog.dart
@@ -105,7 +105,7 @@ class _NIP07Dialog extends State<NIP07Dialog> {
         width: double.maxFinite,
         padding: const EdgeInsets.all(Base.basePaddingHalf),
         decoration: BoxDecoration(
-          color: hintColor.withOpacity(0.3),
+          color: hintColor.withAlpha(76),
           borderRadius: BorderRadius.circular(6),
         ),
         margin: const EdgeInsets.only(
@@ -126,7 +126,7 @@ class _NIP07Dialog extends State<NIP07Dialog> {
           },
           child: Container(
             height: 36,
-            color: hintColor.withOpacity(0.3),
+            color: hintColor.withAlpha(76),
             alignment: Alignment.center,
             child: Text(
               localization.Cancel,
@@ -147,7 +147,7 @@ class _NIP07Dialog extends State<NIP07Dialog> {
           },
           child: Container(
             height: 36,
-            color: hintColor.withOpacity(0.3),
+            color: hintColor.withAlpha(76),
             alignment: Alignment.center,
             child: Text(
               localization.Confirm,

--- a/lib/component/placeholder/metadata_top_placeholder.dart
+++ b/lib/component/placeholder/metadata_top_placeholder.dart
@@ -62,7 +62,7 @@ class MetadataTopPlaceholderWidget extends StatelessWidget {
     topList.add(Container(
       width: maxWidth,
       height: bannerHeight,
-      color: hintColor.withOpacity(0.5),
+      color: hintColor.withAlpha(128),
     ));
     topList.add(SizedBox(
       height: 50,

--- a/lib/component/placeholder/music_placeholder.dart
+++ b/lib/component/placeholder/music_placeholder.dart
@@ -23,7 +23,7 @@ class MusicPlaceholder extends StatelessWidget {
     var imageWidget = Container(
       width: imageHeight,
       height: imageHeight,
-      color: themeData.hintColor.withOpacity(0.5),
+      color: themeData.hintColor.withAlpha(128),
     );
     List<Widget> topList = [
       imageWidget,

--- a/lib/component/primary_button_widget.dart
+++ b/lib/component/primary_button_widget.dart
@@ -27,11 +27,11 @@ class PrimaryButtonWidget extends StatelessWidget {
       borderRadius: BorderRadius.circular(borderRadius),
       child: InkWell(
         onTap: enabled ? onTap : null,
-        highlightColor: buttonColor.withOpacity(0.2),
+        highlightColor: buttonColor.withAlpha(51),
         borderRadius: BorderRadius.circular(borderRadius),
         child: Container(
           decoration: BoxDecoration(
-            color: enabled ? buttonColor : buttonColor.withOpacity(0.4),
+            color: enabled ? buttonColor : buttonColor.withAlpha(102),
             borderRadius: BorderRadius.circular(borderRadius),
           ),
           height: height,
@@ -41,7 +41,7 @@ class PrimaryButtonWidget extends StatelessWidget {
             style: TextStyle(
               fontWeight: FontWeight.bold,
               color:
-                  enabled ? buttonTextColor : buttonTextColor.withOpacity(0.4),
+                  enabled ? buttonTextColor : buttonTextColor.withAlpha(102),
             ),
           ),
         ),

--- a/lib/component/qrcode_dialog.dart
+++ b/lib/component/qrcode_dialog.dart
@@ -120,7 +120,7 @@ class _QrcodeDialog extends State<QrcodeDialog> {
         width: qrWidth + Base.basePaddingHalf * 2,
         padding: const EdgeInsets.all(Base.basePaddingHalf),
         decoration: BoxDecoration(
-          color: hintColor.withOpacity(0.5),
+          color: hintColor.withAlpha(128),
           borderRadius: BorderRadius.circular(10),
         ),
         child: SelectableText(

--- a/lib/component/sync_upload_dialog.dart
+++ b/lib/component/sync_upload_dialog.dart
@@ -140,7 +140,7 @@ class _SyncUploadDialog extends State<SyncUploadDialog> {
           onTap: () {
             beginToUpload();
           },
-          highlightColor: mainColor.withOpacity(0.2),
+          highlightColor: mainColor.withAlpha(51),
           child: Container(
             color: mainColor,
             height: 40,
@@ -286,10 +286,10 @@ class _SyncUploadItem extends State<SyncUploadItem> {
           bottom: Base.basePaddingHalf,
         ),
         decoration: BoxDecoration(
-          color: widget.check ? mainColor.withOpacity(0.2) : null,
+          color: widget.check ? mainColor.withAlpha(51) : null,
           border: Border.all(
             width: 1,
-            color: hintColor.withOpacity(0.5),
+            color: hintColor.withAlpha(128),
           ),
           borderRadius: BorderRadius.circular(Base.basePaddingHalf),
         ),

--- a/lib/component/user/simple_user_widget.dart
+++ b/lib/component/user/simple_user_widget.dart
@@ -87,7 +87,7 @@ class _SimpleUserWidgetState extends State<SimpleUserWidget> {
       bannerImage,
       Container(
         height: height,
-        color: cardColor.withOpacity(0.4),
+        color: cardColor.withAlpha(102),
       ),
       Container(
         padding: const EdgeInsets.only(left: Base.basePadding),

--- a/lib/component/zap/zap_bottom_sheet_widget.dart
+++ b/lib/component/zap/zap_bottom_sheet_widget.dart
@@ -161,7 +161,7 @@ class _ZapBottomSheetWidgetState extends CustState<ZapBottomSheetWidget> {
           onTap: () {
             _onConfirm();
           },
-          highlightColor: mainColor.withOpacity(0.2),
+          highlightColor: mainColor.withAlpha(51),
           child: Container(
             color: mainColor,
             height: 50,
@@ -245,7 +245,7 @@ class _ZapBottomSheetWidgetState extends CustState<ZapBottomSheetWidget> {
         height: width,
         alignment: Alignment.center,
         decoration: BoxDecoration(
-          color: mainColor.withOpacity(0.2),
+          color: mainColor.withAlpha(51),
           borderRadius: BorderRadius.circular(4),
           border: Border.all(
             color: borderColor,

--- a/lib/features/community_guidelines/community_guidelines_screen.dart
+++ b/lib/features/community_guidelines/community_guidelines_screen.dart
@@ -62,7 +62,7 @@ class _CommunityGuidelinesScreenState
             onPressed: isSaveDisabled ? null : () => _save(id),
             style: TextButton.styleFrom(
               foregroundColor: accentColor,
-              disabledForegroundColor: accentColor.withOpacity(0.4),
+              disabledForegroundColor: accentColor.withAlpha(102),
             ),
             child: Text(
               localization.Save,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -658,7 +658,7 @@ class _MyApp extends State<MyApp> {
       extensions: const [light],
       scaffoldBackgroundColor: light.appBgColor,
       primaryColor: light.accentColor,
-      focusColor: light.secondaryForegroundColor.withOpacity(0.1),
+      focusColor: light.secondaryForegroundColor.withAlpha(26),
       appBarTheme: _appBarTheme(
         bgColor: light.navBgColor,
         titleTextStyle: titleTextStyle,
@@ -696,7 +696,7 @@ class _MyApp extends State<MyApp> {
       extensions: const [CustomColors.dark],
       scaffoldBackgroundColor: dark.appBgColor,
       primaryColor: dark.accentColor,
-      focusColor: dark.secondaryForegroundColor.withOpacity(0.1),
+      focusColor: dark.secondaryForegroundColor.withAlpha(26),
       appBarTheme: _appBarTheme(
         bgColor: dark.navBgColor,
         titleTextStyle: titleTextStyle,
@@ -706,7 +706,7 @@ class _MyApp extends State<MyApp> {
       cardColor: dark.cardBgColor,
       textTheme: textTheme,
       hintColor: dark.dimmedColor,
-      shadowColor: Colors.white.withOpacity(0.3),
+      shadowColor: Colors.white.withAlpha(76),
       tabBarTheme: _tabBarTheme(),
       canvasColor: dark.feedBgColor,
       iconTheme: _iconTheme(dark.primaryForegroundColor),

--- a/lib/router/dm/dm_detail_item_widget.dart
+++ b/lib/router/dm/dm_detail_item_widget.dart
@@ -128,7 +128,7 @@ class _DMDetailItemWidgetState extends State<DMDetailItemWidget>
             //     BoxConstraints(maxWidth: (maxWidth - imageWidth) * 0.85),
             decoration: BoxDecoration(
               // color: Colors.red,
-              color: mainColor.withOpacity(0.3),
+              color: mainColor.withAlpha(76),
               borderRadius: const BorderRadius.all(Radius.circular(5)),
             ),
             // child: SelectableText(content),

--- a/lib/router/dm/dm_detail_widget.dart
+++ b/lib/router/dm/dm_detail_widget.dart
@@ -116,7 +116,7 @@ class _DMDetailWidgetState extends CustState<DMDetailWidget> with EditorMixin {
         color: cardColor,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.2),
+            color: Colors.black.withAlpha(51),
             offset: const Offset(0, -5),
             blurRadius: 10,
             spreadRadius: 0,

--- a/lib/router/donate/donate_widget.dart
+++ b/lib/router/donate/donate_widget.dart
@@ -204,7 +204,7 @@ class _DonateButtonWidget extends StatelessWidget {
             style: ButtonStyle(
               side: WidgetStateProperty.all(BorderSide(
                 width: 1,
-                color: hintColor.withOpacity(0.4),
+                color: hintColor.withAlpha(102),
               )),
             ),
             child: Container(

--- a/lib/router/edit/editor_notify_item_widget.dart
+++ b/lib/router/edit/editor_notify_item_widget.dart
@@ -55,13 +55,13 @@ class _EditorNotifyItemWidgetState extends State<EditorNotifyItemWidget> {
             widget.item.selected = !widget.item.selected;
           });
         },
-        side: BorderSide(color: textColor!.withOpacity(0.6), width: 2),
+        side: BorderSide(color: textColor!.withAlpha(153), width: 2),
       ),
     ));
 
     return Container(
       decoration: BoxDecoration(
-        color: mainColor.withOpacity(0.65),
+        color: mainColor.withAlpha(166),
         borderRadius: BorderRadius.circular(15),
       ),
       padding: const EdgeInsets.only(

--- a/lib/router/filter/filter_dirtyword_widget.dart
+++ b/lib/router/filter/filter_dirtyword_widget.dart
@@ -107,7 +107,7 @@ class _FilterDirtywordItemWidgetState extends State<FilterDirtywordItemWidget> {
             bottom: 4,
           ),
           decoration: BoxDecoration(
-            color: mainColor.withOpacity(0.8),
+            color: mainColor.withAlpha(204),
             borderRadius: BorderRadius.circular(4),
           ),
           child: Text(

--- a/lib/router/follow_set/follow_set_feed_widget.dart
+++ b/lib/router/follow_set/follow_set_feed_widget.dart
@@ -41,7 +41,7 @@ class _FollowSetFeedWidgetState extends CustState<FollowSetFeedWidget>
     bindLoadMoreScroll(_controller);
     _controller.addListener(() {
       if (_controller.offset > 50 && mainColor != null) {
-        appBarBG = mainColor!.withOpacity(0.2);
+        appBarBG = mainColor!.withAlpha(51);
         setState(() {});
       } else {
         appBarBG = null;

--- a/lib/router/group/group_add_dialog.dart
+++ b/lib/router/group/group_add_dialog.dart
@@ -82,7 +82,7 @@ class _GroupAddDialog extends State<GroupAddDialog> {
         decoration: BoxDecoration(color: mainColor),
         child: InkWell(
           onTap: _onConfirm,
-          highlightColor: mainColor.withOpacity(0.2),
+          highlightColor: mainColor.withAlpha(51),
           child: Container(
             color: mainColor,
             height: 40,

--- a/lib/router/group/group_detail_chat_widget.dart
+++ b/lib/router/group/group_detail_chat_widget.dart
@@ -91,7 +91,7 @@ class _GroupDetailChatWidgetState extends KeepAliveCustState<GroupDetailChatWidg
         color: cardColor,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.2),
+            color: Colors.black.withAlpha(51),
             offset: const Offset(0, -5),
             blurRadius: 10,
             spreadRadius: 0,

--- a/lib/router/group/invite_people_widget.dart
+++ b/lib/router/group/invite_people_widget.dart
@@ -71,7 +71,7 @@ class InvitePeopleWidget extends StatelessWidget {
                   RouterUtil.router(
                       context, RouterPath.groupDetail, groupIdentifier);
                 },
-                highlightColor: theme.primaryColor.withOpacity(0.2),
+                highlightColor: theme.primaryColor.withAlpha(51),
                 child: Container(
                   color: theme.primaryColor,
                   height: 40,

--- a/lib/router/index/account_manager_widget.dart
+++ b/lib/router/index/account_manager_widget.dart
@@ -92,7 +92,7 @@ class AccountManagerWidgetState extends State<AccountManagerWidget> {
       child: TextButton(
         onPressed: addAccount,
         style: TextButton.styleFrom(
-          side: BorderSide(width: 1, color: hintColor.withOpacity(0.4)),
+          side: BorderSide(width: 1, color: hintColor.withAlpha(102)),
         ),
         child: Text(
           localization.Add_Account,

--- a/lib/router/index/index_drawer_content.dart
+++ b/lib/router/index/index_drawer_content.dart
@@ -317,7 +317,7 @@ class IndexDrawerItemWidget extends StatelessWidget {
       // Compact mode: Only the icon is displayed with minimal padding.
       mainWidget = Container(
         decoration: BoxDecoration(
-          color: color != null ? Colors.white.withOpacity(0.1) : null,
+          color: color != null ? Colors.white.withAlpha(26) : null,
           borderRadius: BorderRadius.circular(14),
         ),
         padding: const EdgeInsets.all(8),

--- a/lib/router/login/login_widget.dart
+++ b/lib/router/login/login_widget.dart
@@ -212,9 +212,9 @@ class _LoginSignupState extends State<LoginSignupWidget> {
         style: FilledButton.styleFrom(
           shape: const RoundedRectangleBorder(borderRadius: BorderRadius.zero),
           backgroundColor: dimmedColor,
-          disabledBackgroundColor: dimmedColor.withOpacity(0.4),
+          disabledBackgroundColor: dimmedColor.withAlpha(102),
           foregroundColor: buttonTextColor,
-          disabledForegroundColor: buttonTextColor.withOpacity(0.4),
+          disabledForegroundColor: buttonTextColor.withAlpha(102),
         ),
         child: Text(
           localization.Login,
@@ -236,10 +236,10 @@ class _LoginSignupState extends State<LoginSignupWidget> {
                 const RoundedRectangleBorder(borderRadius: BorderRadius.zero),
             backgroundColor: themeData.customColors.dimmedColor,
             disabledBackgroundColor:
-                themeData.customColors.dimmedColor.withOpacity(0.4),
+                themeData.customColors.dimmedColor.withAlpha(102),
             foregroundColor: themeData.customColors.buttonTextColor,
             disabledForegroundColor:
-                themeData.customColors.buttonTextColor.withOpacity(0.4),
+                themeData.customColors.buttonTextColor.withAlpha(102),
           ),
           child: Text(
             localization.Login_With_Android_Signer,
@@ -260,10 +260,10 @@ class _LoginSignupState extends State<LoginSignupWidget> {
                 const RoundedRectangleBorder(borderRadius: BorderRadius.zero),
             backgroundColor: themeData.customColors.dimmedColor,
             disabledBackgroundColor:
-                themeData.customColors.dimmedColor.withOpacity(0.4),
+                themeData.customColors.dimmedColor.withAlpha(102),
             foregroundColor: themeData.customColors.buttonTextColor,
             disabledForegroundColor:
-                themeData.customColors.buttonTextColor.withOpacity(0.4),
+                themeData.customColors.buttonTextColor.withAlpha(102),
           ),
           child: Text(
             localization.Login_With_NIP07_Extension,

--- a/lib/router/nwc/nwc_setting_widget.dart
+++ b/lib/router/nwc/nwc_setting_widget.dart
@@ -105,7 +105,7 @@ class _NwcSettingWidgetState extends CustState<NwcSettingWidget> {
         decoration: BoxDecoration(color: mainColor),
         child: InkWell(
           onTap: _onConfirm,
-          highlightColor: mainColor.withOpacity(0.2),
+          highlightColor: mainColor.withAlpha(51),
           child: Container(
             color: mainColor,
             height: 40,
@@ -126,7 +126,7 @@ class _NwcSettingWidgetState extends CustState<NwcSettingWidget> {
       margin: const EdgeInsets.only(top: Base.basePadding),
       padding: const EdgeInsets.all(Base.basePadding),
       decoration: BoxDecoration(
-        color: themeData.hintColor.withOpacity(0.4),
+        color: themeData.hintColor.withAlpha(102),
         borderRadius: BorderRadius.circular(10),
       ),
       child: Text(

--- a/lib/router/settings/development/push_notification_test_widget.dart
+++ b/lib/router/settings/development/push_notification_test_widget.dart
@@ -421,7 +421,7 @@ class _PushNotificationTestWidgetState
 
             // Info card
             Card(
-              color: theme.colorScheme.primary.withOpacity(0.1),
+              color: theme.colorScheme.primary.withAlpha(26),
               child: Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: Column(

--- a/lib/router/thread_trace_router/thread_trace_widget.dart
+++ b/lib/router/thread_trace_router/thread_trace_widget.dart
@@ -114,7 +114,7 @@ class _ThreadTraceWidgetState extends State<ThreadTraceWidget>
                 left: 28,
                 child: Container(
                   width: 2,
-                  color: themeData.hintColor.withOpacity(0.25),
+                  color: themeData.hintColor.withAlpha(64),
                 ),
               ),
               Column(

--- a/lib/util/theme_util.dart
+++ b/lib/util/theme_util.dart
@@ -15,7 +15,7 @@ import 'package:flutter/material.dart';
 class ThemeUtil {
   static Color getDialogCoverColor(ThemeData themeData) {
     return (themeData.textTheme.bodyMedium!.color ?? Colors.black)
-        .withOpacity(0.2);
+        .withAlpha(51);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replaced all deprecated withOpacity() calls with withAlpha() across the codebase
- Used dynamic calculation to convert opacity values to alpha values (alpha = opacity * 255)
- Improved code maintainability and eliminated deprecation warnings
- All tests passing successfully

## Test plan
- Ran flutter analyze to verify the withOpacity deprecation warnings are fixed
- Ran flutter test to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
	- Improved visual consistency and clarity across the app by refining transparency effects in buttons, dialogs, shadows, and backgrounds.
	- Enhanced color rendering for interactive elements to provide sharper focus and a more polished look.

- **Chore**
	- Streamlined internal tooling for updating transparency settings, ensuring consistent visual adjustments throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->