### PR TITLE
Add name collection step to the onboarding process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Release Notes
+- Add name collection to the onboarding flow. [#314](https://github.com/verse-pbc/issues/issues/314)
 
 ### Internal Changes
 

--- a/lib/component/input_field_widget.dart
+++ b/lib/component/input_field_widget.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import '../util/theme_util.dart';
+
+/// Custom input field that is used to take input from the user.
+class InputFieldWidget extends StatelessWidget {
+  /// The hint text to display when the input field is empty.
+  final String? hintText;
+
+  /// The controller for the input field.
+  final TextEditingController controller;
+
+  /// The key for the input field.
+  final Key? textFieldKey;
+
+  const InputFieldWidget({
+    super.key,
+    this.hintText,
+    required this.controller,
+    this.textFieldKey = const Key('input'),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+
+    return SizedBox(
+      height: 37,
+      child: TextField(
+        controller: controller,
+        key: textFieldKey,
+        decoration: InputDecoration(
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
+          hintText: hintText,
+          hintStyle: TextStyle(
+            color: themeData.customColors.dimmedColor,
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: themeData.customColors.dimmedColor,
+            ),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: themeData.customColors.dimmedColor,
+            ),
+            borderRadius: BorderRadius.circular(4),
+          ),
+        ),
+        style: TextStyle(
+          color: themeData.customColors.primaryForegroundColor,
+          fontSize: 16,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -111,6 +111,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "Content": MessageLookupByLibrary.simpleMessage("Content"),
         "Content_warning":
             MessageLookupByLibrary.simpleMessage("Content warning"),
+        "Continue": MessageLookupByLibrary.simpleMessage("Continue"),
         "Copy": MessageLookupByLibrary.simpleMessage("Copy"),
         "Copy_Hex_Key": MessageLookupByLibrary.simpleMessage("Copy Hex Key"),
         "Copy_Key": MessageLookupByLibrary.simpleMessage("Copy Key"),
@@ -535,6 +536,10 @@ class MessageLookup extends MessageLookupByLibrary {
             "The network will take effect the next time the app is launched"),
         "not_found": MessageLookupByLibrary.simpleMessage("not found"),
         "notes_updated": MessageLookupByLibrary.simpleMessage("notes updated"),
+        "onboarding_name_input_hint":
+            MessageLookupByLibrary.simpleMessage("Your name or nickname"),
+        "onboarding_name_input_title":
+            MessageLookupByLibrary.simpleMessage("What should we call you?"),
         "open": MessageLookupByLibrary.simpleMessage("Open"),
         "or": MessageLookupByLibrary.simpleMessage("or"),
         "poll_option_info":

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3560,11 +3560,31 @@ class S {
     );
   }
 
+  /// `What should we call you?`
+  String get onboarding_name_input_title {
+    return Intl.message(
+      'What should we call you?',
+      name: 'onboarding_name_input_title',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `community name`
   String get community_name {
     return Intl.message(
       'community name',
       name: 'community_name',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Your name or nickname`
+  String get onboarding_name_input_hint {
+    return Intl.message(
+      'Your name or nickname',
+      name: 'onboarding_name_input_hint',
       desc: '',
       args: [],
     );
@@ -3605,6 +3625,16 @@ class S {
     return Intl.message(
       'Have an invite link? Tap on it to join a community.',
       name: 'Have_invite_link',
+      desc: '',
+      args: [],
+    );
+  }
+  
+  /// `Continue`
+  String get Continue {
+    return Intl.message(
+      'Continue',
+      name: 'Continue',
       desc: '',
       args: [],
     );

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -369,4 +369,7 @@
     "Start_or_join_a_community": "Start or join a community",
     "Connect_with_others": "Connect with others by creating your own community or joining an existing one with an invite link.",
     "Have_invite_link": "Have an invite link? Tap on it to join a community."
+    "onboarding_name_input_title": "What should we call you?",
+    "onboarding_name_input_hint": "Your name or nickname",
+    "Continue": "Continue"
 }

--- a/lib/router/onboarding/name_input_step_widget.dart
+++ b/lib/router/onboarding/name_input_step_widget.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'onboarding_step_widget.dart';
+import '../../generated/l10n.dart';
+
+/// Handles name/nickname collection in the onboarding process.
+class NameInputStepWidget extends StatefulWidget {
+  final void Function(String name) onContinue;
+
+  const NameInputStepWidget({
+    super.key,
+    required this.onContinue,
+  });
+
+  @override
+  State<NameInputStepWidget> createState() => _NameInputStepWidgetState();
+}
+
+class _NameInputStepWidgetState extends State<NameInputStepWidget> {
+  final TextEditingController _nameController = TextEditingController();
+  bool _isButtonEnabled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController.addListener(_updateButtonState);
+  }
+
+  @override
+  void dispose() {
+    _nameController.removeListener(_updateButtonState);
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _updateButtonState() {
+    final newState = _nameController.text.trim().isNotEmpty;
+    if (_isButtonEnabled != newState) {
+      setState(() {
+        _isButtonEnabled = newState;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final localization = S.of(context);
+
+    return OnboardingStepWidget(
+      emoji: "📛",
+      title: localization.onboarding_name_input_title,
+      titleKey: const Key('name_input_title'),
+      textController: _nameController,
+      textFieldHint: localization.onboarding_name_input_hint,
+      buttons: [
+        OnboardingStepButton(
+          text: localization.Continue,
+          enabled: _isButtonEnabled,
+          onTap: () {
+            final name = _nameController.text.trim();
+            if (name.isNotEmpty) {
+              widget.onContinue(name);
+            }
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/router/onboarding/onboarding_screen.dart
+++ b/lib/router/onboarding/onboarding_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../util/theme_util.dart';
 import 'age_verification_step.dart';
 import 'age_verification_dialog_widget.dart';
+import 'name_input_step_widget.dart';
 import '../../consts/base.dart';
 
 /// Manages the onboarding process through multiple steps.
@@ -15,6 +16,7 @@ class OnboardingWidget extends StatefulWidget {
 class _OnboardingWidgetState extends State<OnboardingWidget> {
   final PageController _pageController = PageController();
   int _currentPage = 0;
+  String? _userName;
 
   @override
   void dispose() {
@@ -26,6 +28,12 @@ class _OnboardingWidgetState extends State<OnboardingWidget> {
     AgeVerificationStep(
       onVerified: _nextPage,
       onDenied: _onAgeDenied,
+    ),
+    NameInputStepWidget(
+      onContinue: (name) {
+        _userName = name;
+        _nextPage();
+      },
     ),
   ];
 
@@ -72,6 +80,6 @@ class _OnboardingWidgetState extends State<OnboardingWidget> {
   }
 
   void _completeOnboarding() {
-    Navigator.of(context).pop(true);
+    Navigator.of(context).pop(_userName);
   }
 }

--- a/lib/router/onboarding/onboarding_step_widget.dart
+++ b/lib/router/onboarding/onboarding_step_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../component/primary_button_widget.dart';
+import '../../component/input_field_widget.dart';
 import '../../util/theme_util.dart';
 
 /// Represents a button in the onboarding step.
@@ -7,10 +8,12 @@ import '../../util/theme_util.dart';
 ///
 class OnboardingStepButton {
   final String text;
+  final bool enabled;
   final VoidCallback onTap;
 
   OnboardingStepButton({
     required this.text,
+    this.enabled = true,
     required this.onTap,
   });
 }
@@ -22,7 +25,9 @@ class OnboardingStepWidget extends StatelessWidget {
   final String emoji;
   final String title;
   final Key? titleKey;
-  final String description;
+  final String? description;
+  final TextEditingController? textController;
+  final String? textFieldHint;
   final List<OnboardingStepButton> buttons;
 
   const OnboardingStepWidget({
@@ -30,9 +35,15 @@ class OnboardingStepWidget extends StatelessWidget {
     required this.emoji,
     required this.title,
     this.titleKey,
-    required this.description,
+    this.description,
+    this.textController,
+    this.textFieldHint,
     required this.buttons,
-  });
+  }) : assert(
+          (description != null && textController == null) ||
+              (description == null && textController != null),
+          'Either description or textController must be provided, but not both',
+        );
 
   @override
   Widget build(BuildContext context) {
@@ -40,65 +51,74 @@ class OnboardingStepWidget extends StatelessWidget {
     final primaryForegroundColor =
         themeData.customColors.primaryForegroundColor;
 
-    return Padding(
-      padding: const EdgeInsets.all(62),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Emoji
-          Text(
-            emoji,
-            textAlign: TextAlign.start,
-            style: const TextStyle(
-              fontSize: 64,
-              height: 1.2,
+    return MediaQuery(
+      data: MediaQuery.of(context).copyWith(viewInsets: EdgeInsets.zero),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 62, vertical: 32),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Emoji
+            Text(
+              emoji,
+              textAlign: TextAlign.start,
+              style: const TextStyle(
+                fontSize: 64,
+                height: 1.2,
+              ),
             ),
-          ),
 
-          const SizedBox(height: 32),
+            const SizedBox(height: 32),
 
-          Text(
-            title,
-            key: titleKey,
-            textAlign: TextAlign.start,
-            style: TextStyle(
-              color: primaryForegroundColor,
-              fontSize: 32,
-              fontWeight: FontWeight.bold,
-              height: 1.2,
+            Text(
+              title,
+              key: titleKey,
+              textAlign: TextAlign.start,
+              style: TextStyle(
+                color: primaryForegroundColor,
+                fontSize: 32,
+                fontWeight: FontWeight.bold,
+                height: 1.2,
+              ),
             ),
-          ),
 
-          const SizedBox(height: 52),
+            const SizedBox(height: 52),
 
-          Text(
-            description,
-            textAlign: TextAlign.start,
-            style: TextStyle(
-              color: themeData.customColors.secondaryForegroundColor,
-              fontSize: 17,
-              height: 1.4,
-            ),
-          ),
-
-          const Spacer(),
-
-          Row(
-            children: List.generate(
-              buttons.length,
-              (index) => [
-                if (index > 0) const SizedBox(width: 22),
-                Expanded(
-                  child: PrimaryButtonWidget(
-                    text: buttons[index].text,
-                    borderRadius: 4,
-                    onTap: buttons[index].onTap,
+            description != null
+                ? Text(
+                    description!,
+                    textAlign: TextAlign.start,
+                    style: TextStyle(
+                      color: themeData.customColors.secondaryForegroundColor,
+                      fontSize: 17,
+                      height: 1.4,
+                    ),
+                  )
+                : InputFieldWidget(
+                    controller: textController!,
+                    hintText: textFieldHint,
                   ),
-                ),
-              ],
-            ).expand((widgets) => widgets).toList(),
-          )
-        ],
+
+            const Spacer(),
+
+            Row(
+              children: List.generate(
+                buttons.length,
+                (index) => [
+                  if (index > 0) const SizedBox(width: 22),
+                  Expanded(
+                    child: PrimaryButtonWidget(
+                      text: buttons[index].text,
+                      borderRadius: 4,
+                      onTap: buttons[index].onTap,
+                      enabled: buttons[index].enabled,
+                    ),
+                  ),
+                ],
+              ).expand((widgets) => widgets).toList(),
+            )
+          ],
+        ),
       ),
     );
   }

--- a/test/sign_up_test.dart
+++ b/test/sign_up_test.dart
@@ -61,7 +61,7 @@ void main() {
     relayLocalDB = null;
   });
 
-  testWidgets('Sign Up flow with age verification',
+  testWidgets('Sign Up flow with age verification and name input',
       (WidgetTester tester) async {
     // Launch the app
     await tester.pumpWidget(const MyApp());
@@ -76,6 +76,17 @@ void main() {
 
     // Accept age verification
     await tester.tap(find.text('Yes'));
+    await tester.pumpAndSettle();
+
+    // Verify we're on the name input step
+    expect(find.byKey(const Key('name_input_title')), findsOneWidget);
+
+    // Enter the name
+    await tester.enterText(find.byKey(const Key('input')), 'Test User');
+    await tester.pumpAndSettle();
+
+    // Tap the continue button
+    await tester.tap(find.text('Continue'));
     await tester.pumpAndSettle();
 
     // verify that the NoCommunitiesWidget is shown
@@ -101,10 +112,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Verify the dialog appears
-    expect(
-      find.byKey(const Key('age_dialog_title')),
-      findsOneWidget
-    );
+    expect(find.byKey(const Key('age_dialog_title')), findsOneWidget);
     expect(
       find.byKey(const Key('age_requirement_message')),
       findsOneWidget,


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/314

## Description

- Includes a name collection input after the age verification onboarding screen.
- Sends a metadata event with the collected name as the name and displayName.
- Registers the user on Sentry on signup.
- Updates the signup test.
- Creates a reusable text input component because there is a common styling that can be reused.

## How to test
1. Navigate to the Account Manager and click Add Account.
2. Try to signup and verify that you are over 16 years old.
3. You should be taken to the name input onboarding step.
     - You should not be able to continue without entering a name/nickname.
     - You should be fully signed up with your name displayed on the sidebar when you are taken to the home screen.

## Screenshots/Video

https://github.com/user-attachments/assets/74eb6a68-3075-4e9a-b30c-ff8e5445c9f8


@Chardot Please review these UI changes to be sure they match the design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the onboarding and sign-up processes by adding a name collection step, allowing you to easily provide your name or nickname.
  - Introduced a refined input experience with clear on-screen guidance and interactive prompts.

- **Tests**
  - Expanded the sign-up flow testing to ensure the new name input step functions smoothly, ensuring a seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->