### PR TITLE
fixed Edit Profile view navigation bar area #329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change user-facing usage of Groups to Communities. [#326](https://github.com/verse-pbc/issues/issues/326)
 - Moved storage of private keys to Keychain/Keystore. [#324](https://github.com/verse-pbc/issues/issues/324)
 - Removed @Name from side menu. [#330](https://github.com/verse-pbc/issues/issues/330)
+- Fixed Edit Profile view navigation bar area. [#329](https://github.com/verse-pbc/issues/issues/329)
 
 ### Internal Changes
 - Standardized on FVM for Flutter version management, removing mise configuration.

--- a/lib/router/profile_editor/profile_editor_widget.dart
+++ b/lib/router/profile_editor/profile_editor_widget.dart
@@ -6,13 +6,12 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/util/router_util.dart';
 
-import '../../component/appbar4stack.dart';
+import '../../component/appbar_back_btn_widget.dart';
 import '../../component/cust_state.dart';
 import '../../consts/base.dart';
 import '../../generated/l10n.dart';
 import '../../main.dart';
 import '../../provider/uploader.dart';
-import '../../util/table_mode_util.dart';
 
 class ProfileEditorWidget extends StatefulWidget {
   const ProfileEditorWidget({super.key});
@@ -62,7 +61,6 @@ class _ProfileEditorWidgetState extends CustState<ProfileEditorWidget> {
     }
 
     final themeData = Theme.of(context);
-    var cardColor = themeData.cardColor;
     var textColor = themeData.textTheme.bodyMedium!.color;
 
     var submitBtn = TextButton(
@@ -77,26 +75,10 @@ class _ProfileEditorWidgetState extends CustState<ProfileEditorWidget> {
       ),
     );
 
-    Color? appbarBackgroundColor = Colors.transparent;
-    var appBar = Appbar4Stack(
-      backgroundColor: appbarBackgroundColor,
-      // title: appbarTitle,
-      action: Container(
-        margin: const EdgeInsets.only(right: Base.basePadding),
-        child: submitBtn,
-      ),
-    );
-
     var margin = const EdgeInsets.only(bottom: Base.basePadding);
     var padding = const EdgeInsets.only(left: 20, right: 20);
 
     List<Widget> list = [];
-
-    if (TableModeUtil.isTableMode()) {
-      list.add(Container(
-        height: 30,
-      ));
-    }
 
     list.add(Container(
       margin: margin,
@@ -195,30 +177,21 @@ class _ProfileEditorWidgetState extends CustState<ProfileEditorWidget> {
     ));
 
     return Scaffold(
+      appBar: AppBar(
+        leading: const AppbarBackBtnWidget(),
+        actions: [
+          submitBtn,
+        ],
+      ),
       body: Stack(
         children: [
-          Container(
-            width: mediaDataCache.size.width,
+          SizedBox(
             height: mediaDataCache.size.height - mediaDataCache.padding.top,
-            margin: EdgeInsets.only(top: mediaDataCache.padding.top),
-            child: Container(
-              color: cardColor,
-              padding: EdgeInsets.only(
-                  top: mediaDataCache.padding.top + Base.basePadding),
-              child: SingleChildScrollView(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: list,
-                ),
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: list,
               ),
-            ),
-          ),
-          Positioned(
-            top: mediaDataCache.padding.top,
-            left: 0,
-            right: 0,
-            child: Container(
-              child: appBar,
             ),
           ),
         ],


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/329

## Description
Fixes an issue where the navigation bar area is crowded and has a line through it on iPad and macOS.

## How to test
1. Sign in.
2. Navigate to side menu.
3. Tap button to edit profile at top right.
4. Notice the navigation bar area.

## Screenshots/Video

| Before | After |
|--------|--------|
|![profile-before](https://github.com/user-attachments/assets/a9101178-3794-40ab-b4c0-33b970b9272f)|![profile-after](https://github.com/user-attachments/assets/08fb3814-c492-40ad-b5b4-cc376d365d59)|

Regression checks:  
iOS:  
<img src="https://github.com/user-attachments/assets/d33b066f-d8a8-4722-b298-8b1b67e924a5" width="340" />  

Android:  
<img src="https://github.com/user-attachments/assets/5961036c-3152-47b5-96ad-455d263c4e09" width="340" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with the navigation bar area in the Edit Profile view for improved appearance and usability.

- **Documentation**
  - Updated the changelog to include the fix for the Edit Profile navigation bar (issue #329).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->