### PR TITLE
Push notification deregistration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed many typos.
 - Removed CODEOWNERS file to simplify repository management.
 - Enabled building for macOS.
+- Deregister users from push notifications on logout [#290](https://github.com/verse-pbc/issues/issues/290)
 
 ## [0.0.5]
 

--- a/lib/router/index/account_manager_widget.dart
+++ b/lib/router/index/account_manager_widget.dart
@@ -147,6 +147,11 @@ class AccountManagerWidgetState extends ConsumerState<AccountManagerWidget> {
 
   Future<void> onLoginTap(int index) async {
     if (settingsProvider.privateKeyIndex != index) {
+      // Deregister push notifications for current account before switching
+      if (nostr != null) {
+        await NotificationUtil.deregisterUserFromPushNotifications(nostr!);
+      }
+
       clearCurrentMemInfo(ref);
       nostr!.close();
       nostr = null;

--- a/lib/router/index/account_manager_widget.dart
+++ b/lib/router/index/account_manager_widget.dart
@@ -13,6 +13,7 @@ import 'package:nostrmo/data/user.dart';
 import 'package:nostrmo/provider/user_provider.dart';
 import 'package:nostrmo/provider/settings_provider.dart';
 import 'package:nostrmo/util/router_util.dart';
+import 'package:nostrmo/util/notification_util.dart';
 import 'package:provider/provider.dart' as legacy_provider;
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -36,7 +37,8 @@ class AccountManagerWidgetState extends ConsumerState<AccountManagerWidget> {
   @override
   Widget build(BuildContext context) {
     final localization = S.of(context);
-    final settingsProvider = legacy_provider.Provider.of<SettingsProvider>(context);
+    final settingsProvider =
+        legacy_provider.Provider.of<SettingsProvider>(context);
     var privateKeyMap = settingsProvider.privateKeyMap;
 
     final themeData = Theme.of(context);
@@ -171,6 +173,12 @@ class AccountManagerWidgetState extends ConsumerState<AccountManagerWidget> {
   static Future<void> onLogoutTap(int index, WidgetRef ref,
       {bool routerBack = true, BuildContext? context}) async {
     var oldIndex = settingsProvider.privateKeyIndex;
+
+    // Deregister push notifications before clearing data
+    if (oldIndex == index && nostr != null) {
+      await NotificationUtil.deregisterUserFromPushNotifications(nostr!);
+    }
+
     clearLocalData(index);
 
     if (oldIndex == index) {

--- a/lib/util/notification_util.dart
+++ b/lib/util/notification_util.dart
@@ -4,6 +4,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/event.dart';
 import '../../main.dart';
 
@@ -47,8 +48,29 @@ class NotificationUtil {
       return false;
     }
 
-    log('Registering user for push notifications with token: $token');
+    final npub = Nip19.encodePubKey(nostr.publicKey);
+    log('Registering user $npub for push notifications with token: $token');
     return registerTokenWithRelay(
+      token: token,
+      nostr: nostr,
+      relayUrl: _defaultRelayUrl,
+    );
+  }
+
+  /// Helper function to deregister the current user from push notifications
+  /// This includes getting the current FCM token and deregistering it with the
+  /// relay.
+  /// Returns true if deregistration was successful, false otherwise
+  static Future<bool> deregisterUserFromPushNotifications(Nostr nostr) async {
+    final token = await getToken();
+    if (token == null) {
+      log('Cannot deregister from push notifications: FCM token is null');
+      return false;
+    }
+
+    final npub = Nip19.encodePubKey(nostr.publicKey);
+    log('Deregistering user $npub from push notifications with token: $token');
+    return deregisterTokenWithRelay(
       token: token,
       nostr: nostr,
       relayUrl: _defaultRelayUrl,

--- a/lib/util/notification_util.dart
+++ b/lib/util/notification_util.dart
@@ -3,9 +3,7 @@ import 'dart:io';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:nostr_sdk/nostr.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:nostr_sdk/event.dart';
 import '../../main.dart';
 
 /// Utility class for handling notifications


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/290

## Description
This PR deregisters the user for push notifications on logout or account switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Push notifications are now automatically deregistered when logging out or switching accounts, improving privacy and notification management.

- **Documentation**
  - Updated changelog to reflect the addition of push notification deregistration functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->