### PR TITLE
Add prominent create button to group list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed @Name from side menu. [#330](https://github.com/verse-pbc/issues/issues/330)
 - Fixed Edit Profile view navigation bar area. [#329](https://github.com/verse-pbc/issues/issues/329)
 - Added confirmation prompt when leaving a group. [#331](https://github.com/verse-pbc/issues/issues/331)
+- Added prominent create community button to the group list view.
 
 ### Internal Changes
 - Standardized on FVM for Flutter version management, removing mise configuration.

--- a/lib/features/communities/communities_grid_widget.dart
+++ b/lib/features/communities/communities_grid_widget.dart
@@ -3,6 +3,9 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 
 import '../../consts/router_path.dart';
 import '../../util/router_util.dart';
+import '../../features/create_community/create_community_dialog.dart';
+import '../../generated/l10n.dart';
+import '../../util/theme_util.dart';
 import 'community_widget.dart';
 
 /// A widget that displays a grid of communities.
@@ -14,6 +17,10 @@ class CommunitiesGridWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    final localization = S.of(context);
+    final separatorColor = themeData.customColors.separatorColor;
+
     return GridView.builder(
       padding: const EdgeInsets.symmetric(vertical: 52),
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
@@ -22,13 +29,56 @@ class CommunitiesGridWidget extends StatelessWidget {
         mainAxisSpacing: 32.0,
         childAspectRatio: 1,
       ),
-      itemCount: groupIds.length,
+      itemCount: groupIds.length + 1, // Add 1 for the create button
       itemBuilder: (context, index) {
-        final groupIdentifier = groupIds[index];
+        if (index == 0) {
+          // Create Community button
+          return InkWell(
+            onTap: () => CreateCommunityDialog.show(context),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: 120,
+                  height: 120,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: separatorColor,
+                      width: 4,
+                    ),
+                  ),
+                  child: Center(
+                    child: Icon(
+                      Icons.add,
+                      size: 48,
+                      color: themeData.customColors.primaryForegroundColor,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: 120,
+                  child: Text(
+                    localization.Create_Community,
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 20,
+                      color: themeData.textTheme.bodyMedium!.color,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    maxLines: 2,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+        final groupIdentifier = groupIds[index - 1];
         return InkWell(
           onTap: () {
-            RouterUtil.router(
-                context, RouterPath.groupDetail, groupIdentifier);
+            RouterUtil.router(context, RouterPath.groupDetail, groupIdentifier);
           },
           child: CommunityWidget(groupIdentifier),
         );


### PR DESCRIPTION
## Issues covered


## Description
This adds a prominent create community button to the list group view.

## How to test
1. Navigate to the Home Screen.
2. Check that you can see the create button and it takes you to create a community.

## Screenshots/Video

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/cfd456f5-3b6d-47f3-974f-2cbaa79ebceb" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/a719df31-73c8-47d9-9ef2-717f8ea8b641" alt="After" width="250"/> |