### PR TITLE
Add privacy selection option while creating a community

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed @Name from side menu. [#330](https://github.com/verse-pbc/issues/issues/330)
 - Fixed Edit Profile view navigation bar area. [#329](https://github.com/verse-pbc/issues/issues/329)
 - Added confirmation prompt when leaving a group. [#331](https://github.com/verse-pbc/issues/issues/331)
+- Add privacy selection option while creating a community.
 
 ### Internal Changes
 - Standardized on FVM for Flutter version management, removing mise configuration.

--- a/lib/data/group_metadata_repository.dart
+++ b/lib/data/group_metadata_repository.dart
@@ -103,6 +103,7 @@ class GroupMetadataRepository {
     final picture = metadata.picture;
     final about = metadata.about;
     final communityGuidelines = metadata.communityGuidelines;
+
     tags.add(["h", groupId]);
     if (name != null && name != "") {
       tags.add(["name", name]);
@@ -110,6 +111,20 @@ class GroupMetadataRepository {
     if (picture != null && picture != "") {
       tags.add(["picture", picture]);
     }
+
+    // Add privacy tags based on metadata flags
+    if (metadata.public == true) {
+      tags.add(["public"]);
+    } else if (metadata.public == false) {
+      tags.add(["private"]);
+    }
+    if (metadata.open == true) {
+      tags.add(["open"]);
+    } else if (metadata.open == false) {
+      tags.add(["closed"]);
+    }
+
+    // Add about and guidelines
     const marker = _communityGuidelinesMarker;
     if (about != null && about != "") {
       if (communityGuidelines != null && communityGuidelines != "") {
@@ -120,6 +135,7 @@ class GroupMetadataRepository {
     } else if (communityGuidelines != null && communityGuidelines != "") {
       tags.add(["about", "$marker\n\n$communityGuidelines"]);
     }
+
     final event = Event(
       nostr!.publicKey,
       EventKind.groupEditMetadata,

--- a/lib/features/create_community/create_community_dialog.dart
+++ b/lib/features/create_community/create_community_dialog.dart
@@ -7,6 +7,7 @@ import 'package:nostrmo/util/theme_util.dart';
 import '../../generated/l10n.dart';
 import 'create_community_controller.dart';
 import 'create_community_widget.dart';
+import 'privacy_selection_widget.dart';
 
 class CreateCommunityDialog extends ConsumerStatefulWidget {
   const CreateCommunityDialog({super.key});
@@ -105,9 +106,10 @@ class _CreateCommunityDialogState extends ConsumerState<CreateCommunityDialog> {
     );
   }
 
-  void _onCreateCommunity(String communityName) async {
+  void _onCreateCommunity(
+      String communityName, CommunityPrivacy privacy) async {
     final controller = ref.read(createCommunityControllerProvider.notifier);
-    final result = await controller.createCommunity(communityName);
+    final result = await controller.createCommunity(communityName, privacy);
     if (!mounted) return;
     final localization = S.of(context);
     if (!result) {
@@ -122,7 +124,7 @@ class _CreateCommunityDialogState extends ConsumerState<CreateCommunityDialog> {
               child: Text(localization.Retry),
               onPressed: () {
                 Navigator.of(context).pop();
-                _onCreateCommunity(communityName);
+                _onCreateCommunity(communityName, privacy);
               },
             ),
             TextButton(

--- a/lib/features/create_community/create_community_widget.dart
+++ b/lib/features/create_community/create_community_widget.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 
 import '../../component/primary_button_widget.dart';
 import '../../generated/l10n.dart';
+import 'privacy_selection_widget.dart';
 
 class CreateCommunityWidget extends StatefulWidget {
-  final void Function(String) onCreateCommunity;
+  final void Function(String, CommunityPrivacy) onCreateCommunity;
 
   const CreateCommunityWidget({super.key, required this.onCreateCommunity});
 
@@ -16,17 +17,19 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
   final TextEditingController _communityNameController =
       TextEditingController();
   bool _isLoading = false;
+  CommunityPrivacy? _selectedPrivacy;
 
   @override
   Widget build(BuildContext context) {
     final localization = S.of(context);
 
     return Center(
-      child: Padding(
+      child: SingleChildScrollView(
         padding: const EdgeInsets.all(20),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               localization.Create_your_community,
@@ -36,7 +39,10 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
               ),
             ),
             const SizedBox(height: 20),
-            Text(localization.Name_your_community),
+            Text(
+              localization.Name_your_community,
+              textAlign: TextAlign.left,
+            ),
             const SizedBox(height: 10),
             TextField(
               controller: _communityNameController,
@@ -48,13 +54,26 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
                 setState(() {});
               },
             ),
-            const SizedBox(height: 20),
+            const SizedBox(height: 30),
+            PrivacySelectionWidget(
+              selectedPrivacy: _selectedPrivacy,
+              onPrivacySelected: (privacy) {
+                setState(() {
+                  _selectedPrivacy = privacy;
+                });
+              },
+            ),
+            const SizedBox(height: 30),
             PrimaryButtonWidget(
-              text: S.of(context).Confirm,
-              onTap: _communityNameController.text.isNotEmpty
+              text: localization.Confirm,
+              onTap: (_communityNameController.text.isNotEmpty &&
+                      _selectedPrivacy != null &&
+                      !_isLoading)
                   ? _createCommunity
                   : null,
-              enabled: _communityNameController.text.isNotEmpty,
+              enabled: _communityNameController.text.isNotEmpty &&
+                  _selectedPrivacy != null &&
+                  !_isLoading,
             ),
           ],
         ),
@@ -69,7 +88,6 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
       _isLoading = true;
     });
 
-    widget.onCreateCommunity(_communityNameController.text);
-    // No need to set _isLoading back to false as we'll transition to the next screen
+    widget.onCreateCommunity(_communityNameController.text, _selectedPrivacy!);
   }
 }

--- a/lib/features/create_community/privacy_selection_widget.dart
+++ b/lib/features/create_community/privacy_selection_widget.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+
+enum CommunityPrivacy {
+  discoverable,
+  inviteOnly,
+}
+
+class PrivacySelectionWidget extends StatelessWidget {
+  final CommunityPrivacy? selectedPrivacy;
+  final void Function(CommunityPrivacy) onPrivacySelected;
+
+  const PrivacySelectionWidget({
+    super.key,
+    required this.selectedPrivacy,
+    required this.onPrivacySelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Choose Privacy Setting'
+        ),
+        const SizedBox(height: 20),
+        _privacyOption(
+          context,
+          CommunityPrivacy.discoverable,
+          'We want to be discovered',
+          'Your community will be visible in search results',
+          Icons.search,
+        ),
+        const SizedBox(height: 20),
+        _privacyOption(
+          context,
+          CommunityPrivacy.inviteOnly,
+          'We want to be invite only',
+          'Your community will only be accessible through invite links',
+          Icons.lock,
+        ),
+      ],
+    );
+  }
+
+  Widget _privacyOption(
+    BuildContext context,
+    CommunityPrivacy privacy,
+    String title,
+    String description,
+    IconData icon,
+  ) {
+    final themeData = Theme.of(context);
+    final isSelected = selectedPrivacy == privacy;
+
+    return InkWell(
+      onTap: () => onPrivacySelected(privacy),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: isSelected ? themeData.primaryColor : themeData.dividerColor,
+            width: isSelected ? 2 : 1,
+          ),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              color: isSelected
+                  ? themeData.primaryColor
+                  : themeData.iconTheme.color,
+              size: 28,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: isSelected
+                          ? themeData.primaryColor
+                          : themeData.textTheme.bodyLarge?.color,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    description,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: themeData.textTheme.bodyMedium?.color,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (isSelected)
+              Icon(
+                Icons.check_circle,
+                color: themeData.primaryColor,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/create_community/privacy_selection_widget.dart
+++ b/lib/features/create_community/privacy_selection_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import '../../generated/l10n.dart';
 enum CommunityPrivacy {
   discoverable,
   inviteOnly,
@@ -17,27 +17,26 @@ class PrivacySelectionWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final localization = S.of(context);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          'Choose Privacy Setting'
-        ),
+        Text(localization.Choose_privacy_setting),
         const SizedBox(height: 20),
         _privacyOption(
           context,
           CommunityPrivacy.discoverable,
-          'We want to be discovered',
-          'Your community will be visible in search results',
+          localization.Be_discovered_title,
+          localization.Be_discovered_description,
           Icons.search,
         ),
         const SizedBox(height: 20),
         _privacyOption(
           context,
           CommunityPrivacy.inviteOnly,
-          'We want to be invite only',
-          'Your community will only be accessible through invite links',
+          localization.Invite_only_title,
+          localization.Invite_only_description,
           Icons.lock,
         ),
       ],

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -71,6 +71,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Backup my notes"),
         "Banner": MessageLookupByLibrary.simpleMessage("Banner"),
         "Base_Mode": MessageLookupByLibrary.simpleMessage("Base Mode"),
+        "Be_discovered_description": MessageLookupByLibrary.simpleMessage(
+            "Your community will be visible in search results"),
+        "Be_discovered_title":
+            MessageLookupByLibrary.simpleMessage("We want to be discovered"),
         "Begin_to_download_translate_model":
             MessageLookupByLibrary.simpleMessage(
                 "Begin to download translate model"),
@@ -88,6 +92,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "Cache_Relay": MessageLookupByLibrary.simpleMessage("Cache Relay"),
         "Cancel": MessageLookupByLibrary.simpleMessage("Cancel"),
         "Chat": MessageLookupByLibrary.simpleMessage("Chat"),
+        "Choose_privacy_setting":
+            MessageLookupByLibrary.simpleMessage("Choose Privacy Setting"),
         "Clear_All_Data":
             MessageLookupByLibrary.simpleMessage("Clear All Data"),
         "Clear_Not_My_Data":
@@ -266,6 +272,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Input parse error"),
         "Input_relay_address":
             MessageLookupByLibrary.simpleMessage("Input relay address."),
+        "Invite_only_description": MessageLookupByLibrary.simpleMessage(
+            "Your community will only be accessible through invite links"),
+        "Invite_only_title":
+            MessageLookupByLibrary.simpleMessage("We want to be invite only"),
         "Join_Community":
             MessageLookupByLibrary.simpleMessage("Join Community"),
         "Language": MessageLookupByLibrary.simpleMessage("Language"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3649,6 +3649,56 @@ class S {
       args: [],
     );
   }
+
+  /// `Choose Privacy Setting`
+  String get Choose_privacy_setting {
+    return Intl.message(
+      'Choose Privacy Setting',
+      name: 'Choose_privacy_setting',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `We want to be discovered`
+  String get Be_discovered_title {
+    return Intl.message(
+      'We want to be discovered',
+      name: 'Be_discovered_title',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Your community will be visible in search results`
+  String get Be_discovered_description {
+    return Intl.message(
+      'Your community will be visible in search results',
+      name: 'Be_discovered_description',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `We want to be invite only`
+  String get Invite_only_title {
+    return Intl.message(
+      'We want to be invite only',
+      name: 'Invite_only_title',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Your community will only be accessible through invite links`
+  String get Invite_only_description {
+    return Intl.message(
+      'Your community will only be accessible through invite links',
+      name: 'Invite_only_description',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -373,5 +373,10 @@
     "Have_invite_link": "Have an invite link? Tap on it to join a community.",
     "onboarding_name_input_title": "What should we call you?",
     "onboarding_name_input_hint": "Your name or nickname",
-    "Continue": "Continue"
+    "Continue": "Continue",
+    "Choose_privacy_setting": "Choose Privacy Setting",
+    "Be_discovered_title": "We want to be discovered",
+    "Be_discovered_description": "Your community will be visible in search results",
+    "Invite_only_title": "We want to be invite only",
+    "Invite_only_description": "Your community will only be accessible through invite links"
 }


### PR DESCRIPTION
## Issues covered


## Description
This PR adds a privacy selection option while creating a community. It also updates the create community controller to enable public or private group creations.

## How to test
1. Navigate to the Home Screen.
2. Tap on the create community button.
3. You should now be able to choose a privacy mode too, instead of just inputing a name.

## Screenshots/Video

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/f6cea1a1-c8a5-4c7e-bbd9-a5e0f208a238" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/bbfa67cf-18fb-4567-8fea-9c4f33bba9e7" alt="After" width="250"/> |

Video:


https://github.com/user-attachments/assets/861b9226-a438-4124-9a5a-44d1a4520c5f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a privacy selection option when creating a community, allowing users to choose between "discoverable" and "invite-only" privacy settings.
  - Introduced a new interface component for selecting community privacy during the creation flow.

- **User Interface**
  - Updated the community creation form to include privacy selection with clear descriptions and visual indicators for each option.

- **Localization**
  - Added new English text strings for privacy selection and descriptions.

- **Documentation**
  - Updated release notes to document the new privacy selection feature for community creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->