### PR TITLE
added DMs with tabbed interface #338

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed @Name from side menu. [#330](https://github.com/verse-pbc/issues/issues/330)
 - Fixed Edit Profile view navigation bar area. [#329](https://github.com/verse-pbc/issues/issues/329)
 - Added confirmation prompt when leaving a group. [#331](https://github.com/verse-pbc/issues/issues/331)
+- Added DMs with tabbed interface. [#338](https://github.com/verse-pbc/issues/issues/338)
 
 ### Internal Changes
 - Standardized on FVM for Flutter version management, removing mise configuration.

--- a/lib/data/dm_session_info.dart
+++ b/lib/data/dm_session_info.dart
@@ -3,7 +3,7 @@ class DMSessionInfo {
 
   String? pubkey;
 
-  /// the last readed event created at
+  /// the last read event's created date
   int? readedTime;
 
   String? value1;

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -293,6 +293,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "Members": MessageLookupByLibrary.simpleMessage("Members"),
         "Mention_User": MessageLookupByLibrary.simpleMessage("Mention User"),
         "Mentions": MessageLookupByLibrary.simpleMessage("Mentions"),
+        "Messages": MessageLookupByLibrary.simpleMessage("Messages"),
         "Metadata_can_not_be_found":
             MessageLookupByLibrary.simpleMessage("Metadata can not be found."),
         "Method": MessageLookupByLibrary.simpleMessage("Method"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -630,6 +630,16 @@ class S {
     );
   }
 
+  /// `Messages`
+  String get Messages {
+    return Intl.message(
+      'Messages',
+      name: 'Messages',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Write a message`
   String get Write_a_message {
     return Intl.message(

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -57,6 +57,7 @@
     "Forbid_profile_picture": "Forbid profile picture",
     "Please_input": "Please input",
     "Notice": "Notice",
+    "Messages": "Messages",
     "Write_a_message": "Write a message",
     "Add_to_known_list": "Add to known list",
     "Buy_me_a_coffee": "Buy me a coffee!",

--- a/lib/provider/relay_provider.dart
+++ b/lib/provider/relay_provider.dart
@@ -147,7 +147,7 @@ class RelayProvider extends ChangeNotifier {
   }
 
   Future<Nostr?> genNostr(NostrSigner signer) async {
-    var pubkey = await signer.getPublicKey();
+    final pubkey = await signer.getPublicKey();
     if (pubkey == null) {
       return null;
     }
@@ -157,6 +157,7 @@ class RelayProvider extends ChangeNotifier {
     log("nostr init over");
 
     // add initQuery
+    dmProvider.initDMSessions(nostr.publicKey);
     contactListProvider.reload(targetNostr: nostr);
     contactListProvider.query(targetNostr: nostr);
     followEventProvider.doQuery(targetNostr: nostr, initQuery: true);

--- a/lib/router/dm/dm_detail_widget.dart
+++ b/lib/router/dm/dm_detail_widget.dart
@@ -59,7 +59,7 @@ class _DMDetailWidgetState extends CustState<DMDetailWidget> with EditorMixin {
     detail = arg as DMSessionDetail;
 
     var dmProvider = Provider.of<DMProvider>(context);
-    var newDetail = dmProvider.getSessionDetail(detail!.dmSession.pubkey);
+    var newDetail = dmProvider.sessionDetailFor(detail!.dmSession.pubkey);
     if (newDetail != null) {
       detail = newDetail;
     }
@@ -270,22 +270,16 @@ class _DMDetailWidgetState extends CustState<DMDetailWidget> with EditorMixin {
 
   @override
   Future<void> onReady(BuildContext context) async {
-    if (detail != null &&
-        detail!.info != null &&
-        detail!.dmSession.newestEvent != null) {
-      dmProvider.updateReadTime(detail);
+    if (detail != null) {
+      dmProvider.updateReadTime(detail!);
     }
   }
 
   @override
-  BuildContext getContext() {
-    return context;
-  }
+  BuildContext getContext() => context;
 
   @override
-  String? getPubkey() {
-    return detail!.dmSession.pubkey;
-  }
+  String? getPubkey() => detail!.dmSession.pubkey;
 
   @override
   List getTags() {

--- a/lib/router/dm/dm_known_list_widget.dart
+++ b/lib/router/dm/dm_known_list_widget.dart
@@ -12,12 +12,22 @@ class DMKnownListWidget extends StatefulWidget {
   const DMKnownListWidget({super.key});
 
   @override
-  State<StatefulWidget> createState() {
-    return _DMKnownListWidgetState();
-  }
+  State<StatefulWidget> createState() =>
+      _DMKnownListWidgetState();
 }
 
 class _DMKnownListWidgetState extends State<DMKnownListWidget> {
+
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final dmProvider = Provider.of<DMProvider>(context, listen: false);
+      dmProvider.query(queryAll: true);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final settingsProvider = Provider.of<SettingsProvider>(context);

--- a/lib/router/dm/dm_session_list_item_widget.dart
+++ b/lib/router/dm/dm_session_list_item_widget.dart
@@ -64,7 +64,7 @@ class _DMSessionListItemWidgetState extends State<DMSessionListItemWidget>
 
         var lastEvent = dmSession.newestEvent!;
 
-        bool hasNewMessage = widget.detail.hasNewMessage();
+        bool hasNewMessage = widget.detail.hasNewMessage;
 
         List<Widget> contentList = [
           Expanded(

--- a/lib/router/dm/dm_unknown_list_widget.dart
+++ b/lib/router/dm/dm_unknown_list_widget.dart
@@ -14,6 +14,17 @@ class DMUnknownListWidget extends StatefulWidget {
 }
 
 class _DMUnknownListWidgetState extends State<DMUnknownListWidget> {
+
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final dmProvider = Provider.of<DMProvider>(context, listen: false);
+      dmProvider.query(queryAll: true);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     var dmProvider = Provider.of<DMProvider>(context);

--- a/lib/router/dm/dm_widget.dart
+++ b/lib/router/dm/dm_widget.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../generated/l10n.dart';
+import '../index/index_tab_item_widget.dart';
 import 'dm_known_list_widget.dart';
 import 'dm_unknown_list_widget.dart';
 
@@ -18,16 +20,45 @@ class _DMWidgetState extends State<DMWidget> {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-
-    return Container(
-      color: themeData.scaffoldBackgroundColor,
-      child: TabBarView(
-        controller: widget.tabController,
-        children: const [
-          DMKnownListWidget(),
-          DMUnknownListWidget(),
-        ],
-      ),
+    final localization = S.of(context);
+    final indicatorColor = themeData.primaryColor;
+    final titleTextColor = themeData.appBarTheme.titleTextStyle!.color;
+    final titleTextStyle = TextStyle(
+      fontSize: 20,
+      fontWeight: FontWeight.bold,
+      color: titleTextColor,
     );
+    return Column(
+        children: [
+          TabBar(
+            indicatorColor: indicatorColor,
+            indicatorWeight: 3,
+            indicatorSize: TabBarIndicatorSize.tab,
+            dividerHeight: 0,
+            tabs: [
+              IndexTabItemWidget(
+                localization.DMs,
+                titleTextStyle,
+                omitText: "DM",
+              ),
+              IndexTabItemWidget(
+                localization.Request,
+                titleTextStyle,
+                omitText: "R",
+              ),
+            ],
+            controller: widget.tabController,
+          ),
+          Expanded(
+            child: TabBarView(
+              controller: widget.tabController,
+              children: const [
+                DMKnownListWidget(),
+                DMUnknownListWidget(),
+              ],
+            ),
+          ),
+        ],
+      );
   }
 }

--- a/lib/router/index/index_bottom_bar.dart
+++ b/lib/router/index/index_bottom_bar.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:nostrmo/provider/index_provider.dart';
 import 'package:provider/provider.dart';
 
-import '../../component/add_btn_wrapper_widget.dart';
+import '../../generated/l10n.dart';
 import '../../main.dart';
 
 class IndexBottomBar extends StatefulWidget {
@@ -20,6 +20,7 @@ class _IndexBottomBar extends State<IndexBottomBar> {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
+    final localization = S.of(context);
     var indexProvider = Provider.of<IndexProvider>(context);
     var currentTap = indexProvider.currentTap;
 
@@ -29,9 +30,10 @@ class _IndexBottomBar extends State<IndexBottomBar> {
 
     list.add(Expanded(
       child: IndexBottomBarButton(
-        iconData: Icons.home_rounded,
+        iconData: Icons.view_comfy_alt,
         index: current,
         selected: current == currentTap,
+        title: localization.Communities,
         onDoubleTap: () {
           indexProvider.followScrollToTop();
         },
@@ -39,26 +41,12 @@ class _IndexBottomBar extends State<IndexBottomBar> {
     ));
     current++;
 
-    if (!nostr!.isReadOnly()) {
-      list.add(Expanded(
-        child: AddBtnWrapperWidget(
-          child: IndexBottomBarButton(
-            iconData: Icons.add_circle_outline_rounded, // notifications_active
-            index: -1,
-            selected: false,
-            bigFont: true,
-            onTap: (value) {
-            },
-          ),
-        ),
-      ));
-    }
-
     list.add(Expanded(
       child: IndexBottomBarButton(
-        iconData: Icons.mail_rounded,
+        iconData: Icons.sms,
         index: current,
         selected: current == currentTap,
+        title: localization.Messages,
       ),
     ));
     current++;
@@ -95,6 +83,7 @@ class IndexBottomBarButton extends StatelessWidget {
   final IconData iconData;
   final int index;
   final bool selected;
+  final String? title;
   final Function(int)? onTap;
   final bool bigFont;
   final Function? onDoubleTap;
@@ -104,6 +93,7 @@ class IndexBottomBarButton extends StatelessWidget {
     required this.iconData,
     required this.index,
     required this.selected,
+    this.title,
     this.onTap,
     this.onDoubleTap,
     this.bigFont = false,
@@ -133,10 +123,21 @@ class IndexBottomBarButton extends StatelessWidget {
       },
       child: SizedBox(
         height: IndexBottomBar.height,
-        child: Icon(
-          iconData,
-          color: selected ? selectedColor : null,
-          size: bigFont ? 40 : null,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              iconData,
+              color: selected ? selectedColor : null,
+              size: bigFont ? 40 : null,
+            ),
+            if (title != null)
+              Text(title!,
+                  style: TextStyle(
+                    color: selected ? selectedColor : null,
+                    fontSize: 12,
+                  ))
+          ],
         ),
       ),
     );

--- a/lib/router/index/index_widget.dart
+++ b/lib/router/index/index_widget.dart
@@ -6,12 +6,9 @@ import 'package:bot_toast/bot_toast.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:nostrmo/component/music/music_widget.dart';
 import 'package:nostrmo/component/cust_state.dart';
 import 'package:nostrmo/component/pc_router_fake.dart';
-import 'package:nostrmo/consts/base.dart';
 import 'package:nostrmo/consts/base_consts.dart';
-import 'package:nostrmo/provider/music_provider.dart';
 import 'package:nostrmo/provider/pc_router_fake_provider.dart';
 import 'package:nostrmo/router/index/index_pc_drawer_wrapper.dart';
 import 'package:provider/provider.dart';
@@ -26,10 +23,9 @@ import '../../util/auth_util.dart';
 import '../../util/table_mode_util.dart';
 import '../dm/dm_widget.dart';
 import '../login/login_widget.dart';
-import '../search/search_widget.dart';
 import 'index_app_bar.dart';
+import 'index_bottom_bar.dart';
 import 'index_drawer_content.dart';
-import 'index_tab_item_widget.dart';
 
 /// Main navigation hub of the application that manages different sections including:
 /// * Groups
@@ -169,7 +165,6 @@ class _IndexWidgetState extends CustState<IndexWidget>
       fontWeight: FontWeight.bold,
       color: titleTextColor,
     );
-    Color? indicatorColor = themeData.primaryColor;
 
     // Build app bar content based on current tab
     Widget? appBarCenter;
@@ -188,108 +183,40 @@ class _IndexWidgetState extends CustState<IndexWidget>
         child: const Icon(Icons.group_add),
       );
     } else if (indexProvider.currentTap == 1) {
-      appBarCenter = TabBar(
-        indicatorColor: indicatorColor,
-        indicatorWeight: 3,
-        indicatorSize: TabBarIndicatorSize.tab,
-        dividerHeight: 0,
-        tabs: [
-          IndexTabItemWidget(
-            localization.Notes,
-            titleTextStyle,
-            omitText: "N",
-          ),
-          IndexTabItemWidget(
-            localization.Users,
-            titleTextStyle,
-            omitText: "U",
-          ),
-          IndexTabItemWidget(
-            localization.Topics,
-            titleTextStyle,
-            omitText: "T",
-          ),
-        ],
-        controller: globalsTabController,
-      );
-    } else if (indexProvider.currentTap == 2) {
       appBarCenter = Center(
         child: Text(
-          localization.Search,
+          localization.Messages,
           style: titleTextStyle,
         ),
       );
-    } else if (indexProvider.currentTap == 3) {
-      appBarCenter = TabBar(
-        indicatorColor: indicatorColor,
-        indicatorWeight: 3,
-        indicatorSize: TabBarIndicatorSize.tab,
-        dividerHeight: 0,
-        tabs: [
-          IndexTabItemWidget(
-            localization.DMs,
-            titleTextStyle,
-            omitText: "DM",
-          ),
-          IndexTabItemWidget(
-            localization.Request,
-            titleTextStyle,
-            omitText: "R",
-          ),
-        ],
-        controller: dmTabController,
-      );
     }
 
-    var mainCenterWidget = MediaQuery.removePadding(
-      context: context,
-      removeTop: true,
-      child: Expanded(
-          child: IndexedStack(
-        index: indexProvider.currentTap,
-        children: [
-          const CommunitiesScreen(),
-          const SearchWidget(),
-          DMWidget(
-            tabController: dmTabController,
-          ),
-        ],
-      )),
-    );
-
-    List<Widget> mainIndexList = [
-      Column(
-        children: [
-          IndexAppBar(
-            center: appBarCenter,
-            right: appBarRight,
-          ),
-          mainCenterWidget,
-        ],
-      ),
-      Positioned(
-        bottom: Base.basePadding,
-        left: 0,
-        right: 0,
-        child: Selector<MusicProvider, MusicInfo?>(
-          builder: ((context, musicInfo, child) {
-            if (musicInfo != null) {
-              return MusicWidget(
-                musicInfo,
-                clearable: true,
-              );
-            }
-
-            return Container();
-          }),
-          selector: (_, provider) {
-            return provider.musicInfo;
-          },
-        ),
-      )
-    ];
     Widget mainIndex = Stack(
-      children: mainIndexList,
+      children: [
+        Column(
+          children: [
+            IndexAppBar(
+              center: appBarCenter,
+              right: appBarRight,
+            ),
+            MediaQuery.removePadding(
+              context: context,
+              removeTop: true,
+              child: Expanded(
+                  child: IndexedStack(
+                index: indexProvider.currentTap,
+                children: [
+                  const CommunitiesScreen(),
+                  DMWidget(
+                    tabController: dmTabController,
+                  ),
+                ],
+              )),
+            ),
+            const IndexBottomBar(),
+          ],
+        ),
+      ],
     );
 
     if (TableModeUtil.isTableMode()) {
@@ -304,8 +231,6 @@ class _IndexWidgetState extends CustState<IndexWidget>
       }
 
       var mainScaffold = Scaffold(
-        // floatingActionButton: addBtn,
-        // floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
         body: Row(children: [
           IndexPcDrawerWrapper(
             fixWidth: column0Width,


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/338

## Description
Added access to DMs.

## How to test
1. Navigate to main view.
2. Tap Messages tab at bottom right.

Note:
The way it currently works, all DMs initially appear in the Requests side, and you have to manually add them to the DMs side by tapping the "Add to known" button. This should be improved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced direct messages (DMs) with a tabbed interface for improved navigation and organization.
  - Added localized tab titles and labels, including a new "Messages" localization entry.
  - Updated bottom navigation bar with new icons and localized titles for "Communities" and "Messages".

- **Refactor**
  - Simplified and streamlined DM provider logic for improved performance and maintainability.
  - Refactored DM session and list widgets for concise code and better initialization of DM data.
  - Enhanced the DM UI to display a visible tab bar above the DM content.

- **Style**
  - Updated button layouts and text styles in the bottom navigation bar for a clearer, more modern look.

- **Documentation**
  - Updated changelog to reflect the addition of DMs with a tabbed interface.
  - Improved code comments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->