### PR TITLE
Create reusable invites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed CODEOWNERS file to simplify repository management.
 - Enabled building for macOS.
 - Deregister users from push notifications on logout [#290](https://github.com/verse-pbc/issues/issues/290)
+- Added "reusable" tag when generating invites.
 
 ## [0.0.5]
 

--- a/lib/data/group_repository.dart
+++ b/lib/data/group_repository.dart
@@ -103,7 +103,8 @@ class GroupRepository {
   }) async {
     final tags = [
       ["h", group.groupId],
-      ["code", inviteCode]
+      ["code", inviteCode],
+      ["reusable"]
     ];
     if (roles != null && roles.isNotEmpty) {
       tags.add(["roles", ...roles]);

--- a/lib/provider/list_provider.dart
+++ b/lib/provider/list_provider.dart
@@ -333,12 +333,13 @@ class ListProvider extends ChangeNotifier {
 
     notifyListeners();
   }
-  
+
   String createInviteLink(GroupIdentifier group, String inviteCode,
       {List<String>? roles}) {
     final tags = [
       ["h", group.groupId],
       ["code", inviteCode],
+      ["reusable"],
     ];
 
     // Add roles if provided, default to "member"
@@ -453,9 +454,9 @@ class ListProvider extends ChangeNotifier {
     if (event.kind == EventKind.groupEditMetadata) {
       _extractGroupIdentifiersFromTags(event, tagPrefix: "h")
           .forEach((groupId) {
-            groupProvider.onEvent(groupId, event);
-            _queryGroupMetadata(groupId);
-          });
+        groupProvider.onEvent(groupId, event);
+        _queryGroupMetadata(groupId);
+      });
       notifyListeners();
     }
   }


### PR DESCRIPTION
## Description
Updates our invitation creation logic to add the "reusable" tag since Daniel will be requiring that on the server side soon to generate an invitation code with unlimited uses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Invite links now include a "reusable" tag, indicating that generated invites can be reused.
- **Documentation**
	- Updated changelog to document the addition of the "reusable" tag for invite generation.
- **Style**
	- Improved code indentation for better readability in event handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->